### PR TITLE
OAuth 2.0 + JWT 인증 시스템 구현

### DIFF
--- a/API_SPECIFICATION.md
+++ b/API_SPECIFICATION.md
@@ -1,626 +1,337 @@
-# 🚀 Fithub Spring Boot API 명세서
+# FitHub API Specification
 
-> **Version**: 1.0.0  
-> **Base URL**: `http://localhost:8080/api/v1`  
-> **Swagger UI**: `http://localhost:8080/swagger-ui.html`  
-> **OpenAPI JSON**: `http://localhost:8080/v3/api-docs`
+프론트엔드에서 필요한 REST API 명세입니다.
 
 ---
 
-## 📋 목차
-
-1. [인증 (Authentication)](#인증)
-2. [파이프라인 API](#파이프라인-api)
-3. [Issue API](#issue-api)
-4. [프로젝트 API](#프로젝트-api)
-5. [에러 응답](#에러-응답)
-
----
-
-## 🔐 인증
-
-### 인증 방식
-
-**GitHub OAuth 2.0**
+## 📌 Base URL
 
 ```
-Authorization: Bearer <GitHub_Access_Token>
-또는
-?accessToken=<GitHub_Access_Token>
+http://localhost:8080/api/v1
 ```
 
 ---
 
-## 📊 파이프라인 API
+## 🔐 Authentication
 
-### 1. 프로젝트 파이프라인 조회
+모든 요청에 JWT 토큰 필요:
+
+```
+Authorization: Bearer <JWT_TOKEN>
+```
+
+---
+
+## 1. GitHub Repository 관리 API
+
+### 1-1. 사용 가능한 GitHub 레포 조회
+
+**사용 시나리오**: 프로젝트 생성 후, 사용자의 GitHub 레포 목록 표시
 
 ```http
-GET /pipelines/project/{projectId}
+GET /projects/{projectId}/repositories/github-available
 ```
 
-**Parameters:**
-- `projectId` (path, required): Spring Project ID
-
-**Response (200 OK):**
+**Response (200 OK)**
 ```json
 {
-  "pipelines": [
+  "repositories": [
     {
-      "id": 1,
-      "project_id": 1,
-      "category": "기능 개발",
-      "version": 2,
-      "is_active": true,
-      "steps": [
-        {
-          "id": 1,
-          "pipeline_id": 1,
-          "title": "회원가입 기능 개발",
-          "description": "소셜 로그인 연동",
-          "is_completed": false,
-          "origin": "ai_generated"
-        }
-      ]
+      "id": 1207474638,
+      "name": "travel-plan",
+      "fullName": "KYH-99/travel-plan",
+      "description": "Travel planning app",
+      "htmlUrl": "https://github.com/KYH-99/travel-plan",
+      "isPrivate": false,
+      "language": "Python",
+      "stargazersCount": 1,
+      "openIssuesCount": 1
     }
   ],
   "total": 1
 }
 ```
 
-**Error Responses:**
-- `404`: 프로젝트를 찾을 수 없음
-- `503`: FastAPI 서버 연결 실패
-
 ---
 
-### 2. AI 파이프라인 생성
+### 1-2. GitHub 레포 동기화 (프로젝트에 등록)
+
+**사용 시나리오**: 사용자가 레포를 선택 → 직군(category) 지정 후 등록
 
 ```http
-POST /pipelines/generate
+POST /projects/{projectId}/repositories/sync-from-github
+Content-Type: application/json
 ```
 
-**Parameters:**
-- `projectId` (query, required): 프로젝트 ID
-- `requirements` (query, required): 개발 요구사항 텍스트
-- `category` (query, optional): 카테고리 (예: "기능개발", "버그수정")
-
-**Request Example:**
-```bash
-POST /api/v1/pipelines/generate?projectId=1&requirements=회원가입%20기능%20구현&category=기능개발
-```
-
-**Response (201 Created):**
+**Request Body**
 ```json
 {
-  "id": 1,
-  "project_id": 1,
-  "category": "기능개발",
-  "version": 1,
-  "is_active": true,
-  "steps": [
+  "githubRepoIds": [1207474638, 1206745673],
+  "categoryMappings": [
     {
-      "id": 1,
-      "pipeline_id": 1,
-      "title": "데이터베이스 스키마 설계",
-      "description": "사용자 테이블 생성",
-      "is_completed": false,
-      "origin": "ai_generated"
+      "githubRepoId": 1207474638,
+      "repoName": "travel-plan",
+      "category": "BE"
     },
     {
-      "id": 2,
-      "pipeline_id": 1,
-      "title": "API 엔드포인트 구현",
-      "description": "회원가입 API 개발",
-      "is_completed": false,
-      "origin": "ai_generated"
+      "githubRepoId": 1206745673,
+      "repoName": "IT",
+      "category": "AI"
     }
   ]
 }
 ```
 
-**Error Responses:**
-- `400`: 잘못된 요청 데이터
-- `503`: FastAPI 서버 연결 실패
-
----
-
-### 3. 파이프라인에 스텝 추가
-
-```http
-POST /pipelines/{pipelineId}/steps
-```
-
-**Parameters:**
-- `pipelineId` (path, required): 파이프라인 ID
-- `title` (query, required): 스텝 제목
-- `description` (query, required): 스텝 설명
-
-**Response (201 Created):**
-```json
-{
-  "id": 3,
-  "pipeline_id": 1,
-  "title": "UI 컴포넌트 구현",
-  "description": "회원가입 폼 개발",
-  "is_completed": false,
-  "origin": "user_created"
-}
-```
-
----
-
-### 4. 파이프라인 스텝 완료 처리
-
-```http
-PATCH /pipelines/steps/{stepId}/complete
-```
-
-**Parameters:**
-- `stepId` (path, required): 파이프라인 스텝 ID
-
-**Response (200 OK):**
-```
-(Empty Body)
-```
-
----
-
-### 5. 파이프라인을 GitHub Issues로 동기화
-
-```http
-POST /pipelines/{pipelineId}/sync-to-github
-```
-
-**Parameters:**
-- `pipelineId` (path, required): 파이프라인 ID
-- `repositoryId` (query, required): Spring Repository ID
-- `accessToken` (query, required): GitHub Access Token
-
-**Response (200 OK):**
+**Response (201 Created)**
 ```json
 [
   {
     "id": 1,
-    "issue_id": 101,
-    "github_issue_number": 42,
-    "repository_id": 1,
-    "status": "SYNCED",
-    "github_url": "https://github.com/owner/repo/issues/42",
-    "error_message": null,
-    "created_at": "2026-04-10T00:05:00Z",
-    "updated_at": "2026-04-10T00:05:00Z"
+    "projectId": 1,
+    "repoUrl": "https://github.com/KYH-99/travel-plan",
+    "repoType": "GITHUB",
+    "category": "BE"
   }
 ]
 ```
 
-**Error Responses:**
-- `400`: GitHub 동기화 실패
-- `401`: GitHub 인증 실패
-- `404`: 파이프라인 또는 저장소를 찾을 수 없음
+---
+
+### 1-3. 프로젝트의 등록된 레포 목록 조회
+
+**사용 시나리오**: 파이프라인 생성 시, 어떤 레포들이 등록되어 있는지 확인
+
+```http
+GET /projects/{projectId}/repositories
+```
+
+**Response (200 OK)**
+```json
+[
+  {
+    "id": 1,
+    "projectId": 1,
+    "repoUrl": "https://github.com/KYH-99/travel-plan",
+    "repoType": "GITHUB",
+    "category": "BE"
+  }
+]
+```
 
 ---
 
-## 🔴 Issue API
+## 2. Pipeline 생성 및 관리 API
 
-### 1. Issue 상세 조회
+### 2-1. 모든 카테고리 파이프라인 일괄 생성 (PDF 지원)
+
+**사용 시나리오**: 레포 등록 후, 전체 파이프라인을 한 번에 생성
 
 ```http
-GET /issues/{issueId}
+POST /pipelines/generate-all
+Content-Type: multipart/form-data
+
+Body:
+- projectId: 1
+- prdFile: (optional) PDF file
 ```
 
-**Response (200 OK):**
+**Response (201 Created)**
 ```json
 {
-  "id": 101,
-  "repository_id": 1,
-  "github_issue_number": 42,
-  "title": "회원가입 기능 구현",
-  "description": "소셜 로그인 연동",
-  "status": "OPEN",
-  "pipeline_step_id": 1,
-  "created_at": "2026-04-10T00:00:00Z",
-  "updated_at": "2026-04-10T00:05:00Z"
+  "projectId": 1,
+  "count": 2,
+  "pipelines": [
+    {
+      "id": 1,
+      "projectId": 1,
+      "category": "BE",
+      "version": 1,
+      "isActive": true,
+      "steps": [
+        {
+          "id": 1,
+          "pipelineId": 1,
+          "title": "API 설계",
+          "description": "REST API 설계",
+          "isCompleted": false,
+          "origin": "ai_generated"
+        }
+      ]
+    }
+  ]
 }
 ```
 
 ---
 
-### 2. 저장소별 Issue 목록 조회
+### 2-2. Pipeline Step 수정
+
+**사용 시나리오**: 개발자/기획자가 AI 생성 스텝을 수정
+
+```http
+PUT /pipelines/steps/{stepId}
+Content-Type: application/json
+```
+
+**Request Body** (모든 필드 선택)
+```json
+{
+  "title": "REST API 및 GraphQL 설계",
+  "description": "API 설계 및 문서화",
+  "is_completed": false
+}
+```
+
+**Response (200 OK)**
+```json
+{
+  "id": 1,
+  "pipelineId": 1,
+  "title": "REST API 및 GraphQL 설계",
+  "description": "API 설계 및 문서화",
+  "isCompleted": false,
+  "origin": "ai_generated"
+}
+```
+
+---
+
+## 3. Issue 생성 및 GitHub 동기화 API
+
+### 3-1. Pipeline Step에서 Issue 생성
+
+**사용 시나리오**: 파이프라인 스텝을 실제 작업 Issue로 변환
+
+```http
+POST /pipelines/steps/{pipelineStepId}/create-issue
+Content-Type: application/json
+```
+
+**Request Body**
+```json
+{
+  "repositoryId": 1,
+  "title": "API 설계",
+  "description": "REST API 설계 및 문서화"
+}
+```
+
+**Response (201 Created)**
+```json
+{
+  "id": 1,
+  "repositoryId": 1,
+  "pipelineStepId": 1,
+  "title": "API 설계",
+  "description": "REST API 설계 및 문서화",
+  "status": "PENDING",
+  "createdAt": "2026-04-12T10:00:00Z"
+}
+```
+
+---
+
+### 3-2. 저장소별 Issue 목록 조회
+
+**사용 시나리오**: 특정 레포의 모든 Issue 확인
 
 ```http
 GET /issues/repository/{repositoryId}
 ```
 
-**Response (200 OK):**
-```json
-[
-  {
-    "id": 101,
-    "repository_id": 1,
-    "github_issue_number": 42,
-    "title": "회원가입 기능 구현",
-    "description": "소셜 로그인 연동",
-    "status": "OPEN",
-    "pipeline_step_id": 1,
-    "created_at": "2026-04-10T00:00:00Z",
-    "updated_at": "2026-04-10T00:05:00Z"
-  }
-]
-```
-
----
-
-### 3. Issue 동기화 상태 조회
-
-```http
-GET /issues/sync/{issueId}
-```
-
-**Response (200 OK):**
-```json
-{
-  "id": 1,
-  "issue_id": 101,
-  "github_issue_number": 42,
-  "repository_id": 1,
-  "status": "SYNCED",
-  "github_url": "https://github.com/owner/repo/issues/42",
-  "error_message": null,
-  "created_at": "2026-04-10T00:05:00Z",
-  "updated_at": "2026-04-10T00:05:00Z"
-}
-```
-
----
-
-### 4. 상태별 Issue 조회
-
-```http
-GET /issues/sync/repository/{repositoryId}/status/{status}
-```
-
-**Parameters:**
-- `repositoryId` (path, required): 저장소 ID
-- `status` (path, required): 동기화 상태 (`PENDING`, `SYNCED`, `FAILED`, `CLOSED`)
-
-**Response (200 OK):**
+**Response (200 OK)**
 ```json
 [
   {
     "id": 1,
-    "issue_id": 101,
-    "github_issue_number": 42,
-    "repository_id": 1,
-    "status": "SYNCED",
-    "github_url": "https://github.com/owner/repo/issues/42",
-    "error_message": null,
-    "created_at": "2026-04-10T00:05:00Z",
-    "updated_at": "2026-04-10T00:05:00Z"
+    "repositoryId": 1,
+    "pipelineStepId": 1,
+    "title": "API 설계",
+    "description": "REST API 설계 및 문서화",
+    "status": "PENDING",
+    "createdAt": "2026-04-12T10:00:00Z"
   }
 ]
 ```
 
 ---
 
-### 5. Issue 상태 업데이트
+### 3-3. Issue를 GitHub로 동기화
+
+**사용 시나리오**: Spring Issue를 실제 GitHub Issue로 생성
 
 ```http
-PATCH /issues/{issueId}/status
+POST /issues/{issueId}/sync?repoUrl=https://github.com/KYH-99/travel-plan
+Authorization: Bearer <JWT_TOKEN>
 ```
 
-**Parameters:**
-- `issueId` (path, required): Issue ID
-- `status` (query, required): 새로운 상태 (`OPEN`, `CLOSED`)
-- `repoUrl` (query, required): GitHub 저장소 URL (예: `https://github.com/owner/repo`)
-- `accessToken` (query, required): GitHub Access Token
+**Query Parameters**
+- `repoUrl`: GitHub 저장소 URL
 
-**Response (200 OK):**
-```json
-{
-  "issueId": "101",
-  "status": "CLOSED",
-  "message": "Issue status updated successfully"
-}
-```
-
----
-
-### 6. Issue를 GitHub로 동기화
-
-```http
-POST /issues/{issueId}/sync
-```
-
-**Parameters:**
-- `issueId` (path, required): Issue ID
-- `repoUrl` (query, required): GitHub 저장소 URL
-- `accessToken` (query, required): GitHub Access Token
-
-**Response (201 Created):**
+**Response (201 Created)**
 ```json
 {
   "id": 1,
-  "issue_id": 101,
-  "github_issue_number": 42,
-  "repository_id": 1,
+  "issueId": 1,
+  "repositoryId": 1,
+  "githubIssueNumber": 42,
   "status": "SYNCED",
-  "github_url": "https://github.com/owner/repo/issues/42",
-  "error_message": null,
-  "created_at": "2026-04-10T00:05:00Z",
-  "updated_at": "2026-04-10T00:05:00Z"
+  "githubUrl": "https://github.com/KYH-99/travel-plan/issues/42",
+  "syncedAt": "2026-04-12T10:10:00Z"
 }
 ```
 
 ---
 
-## 📁 프로젝트 API
+## 4. Frontend Workflow
 
-### 1. 프로젝트 조회
-
-```http
-GET /projects/{projectId}
+### Step 1: GitHub 레포 등록
+```
+GET /projects/{projectId}/repositories/github-available
+  ↓ (사용자가 레포 선택 + 카테고리 지정)
+POST /projects/{projectId}/repositories/sync-from-github
 ```
 
-**Response (200 OK):**
+### Step 2: 파이프라인 생성
+```
+POST /pipelines/generate-all
+```
+
+### Step 3: Pipeline Step 수정 (선택)
+```
+PUT /pipelines/steps/{stepId}
+```
+
+### Step 4: Issue 생성
+```
+POST /pipelines/steps/{pipelineStepId}/create-issue
+```
+
+### Step 5: GitHub 동기화
+```
+POST /issues/{issueId}/sync?repoUrl=...&accessToken=...
+```
+
+---
+
+## 5. Error Responses
+
 ```json
 {
-  "id": 1,
-  "name": "Fithub",
-  "description": "AI 기반 협업 허브",
-  "created_at": "2026-04-01T10:00:00Z",
-  "updated_at": "2026-04-10T00:00:00Z"
-}
-```
-
----
-
-### 2. 프로젝트 생성
-
-```http
-POST /projects
-```
-
-**Parameters:**
-- `name` (query, required): 프로젝트 이름
-- `description` (query, optional): 프로젝트 설명
-
-**Response (201 Created):**
-```json
-{
-  "id": 1,
-  "name": "Fithub",
-  "description": "AI 기반 협업 허브",
-  "created_at": "2026-04-10T00:05:00Z",
-  "updated_at": "2026-04-10T00:05:00Z"
-}
-```
-
----
-
-### 3. 프로젝트 정보 수정
-
-```http
-PATCH /projects/{projectId}
-```
-
-**Parameters:**
-- `projectId` (path, required): 프로젝트 ID
-- `name` (query, optional): 새로운 프로젝트 이름
-- `description` (query, optional): 새로운 프로젝트 설명
-
-**Response (200 OK):**
-```json
-{
-  "id": 1,
-  "name": "Fithub v2",
-  "description": "AI 기반 협업 허브 - 개선 버전",
-  "created_at": "2026-04-01T10:00:00Z",
-  "updated_at": "2026-04-10T00:06:00Z"
-}
-```
-
----
-
-### 4. 프로젝트 삭제
-
-```http
-DELETE /projects/{projectId}
-```
-
-**Response (204 No Content):**
-```
-(Empty Body)
-```
-
----
-
-### 5. 프로젝트 멤버 목록 조회
-
-```http
-GET /projects/{projectId}/members
-```
-
-**Response (200 OK):**
-```json
-[
-  {
-    "id": 1,
-    "project_id": 1,
-    "user_id": 10,
-    "role": "PM",
-    "joined_at": "2026-04-01T10:00:00Z",
-    "updated_at": "2026-04-10T00:00:00Z"
-  },
-  {
-    "id": 2,
-    "project_id": 1,
-    "user_id": 11,
-    "role": "BE",
-    "joined_at": "2026-04-02T10:00:00Z",
-    "updated_at": "2026-04-10T00:00:00Z"
-  }
-]
-```
-
----
-
-### 6. 프로젝트에 멤버 추가
-
-```http
-POST /projects/{projectId}/members
-```
-
-**Parameters:**
-- `projectId` (path, required): 프로젝트 ID
-- `userId` (query, required): 사용자 ID
-- `role` (query, required): 멤버 역할 (예: `PM`, `FE`, `BE`, `AI`)
-
-**Response (201 Created):**
-```json
-{
-  "id": 3,
-  "project_id": 1,
-  "user_id": 12,
-  "role": "FE",
-  "joined_at": "2026-04-10T00:07:00Z",
-  "updated_at": "2026-04-10T00:07:00Z"
-}
-```
-
----
-
-### 7. 멤버 역할 수정
-
-```http
-PATCH /projects/{projectId}/members/{memberId}/role
-```
-
-**Parameters:**
-- `projectId` (path, required): 프로젝트 ID
-- `memberId` (path, required): 멤버 ID
-- `role` (query, required): 새로운 역할
-
-**Response (200 OK):**
-```json
-{
-  "id": 3,
-  "project_id": 1,
-  "user_id": 12,
-  "role": "BE",
-  "joined_at": "2026-04-10T00:07:00Z",
-  "updated_at": "2026-04-10T00:08:00Z"
-}
-```
-
----
-
-### 8. 멤버 삭제
-
-```http
-DELETE /projects/{projectId}/members/{memberId}
-```
-
-**Response (204 No Content):**
-```
-(Empty Body)
-```
-
----
-
-### 9. 특정 사용자의 프로젝트 멤버 조회
-
-```http
-GET /projects/{projectId}/members/{userId}
-```
-
-**Response (200 OK):**
-```json
-{
-  "id": 1,
-  "project_id": 1,
-  "user_id": 10,
-  "role": "PM",
-  "joined_at": "2026-04-01T10:00:00Z",
-  "updated_at": "2026-04-10T00:00:00Z"
-}
-```
-
----
-
-## ⚠️ 에러 응답
-
-### 400 Bad Request
-```json
-{
-  "timestamp": "2026-04-10T00:05:00Z",
+  "timestamp": "2026-04-12T10:00:00Z",
   "status": 400,
   "error": "Bad Request",
-  "message": "Invalid request parameters"
+  "message": "Invalid request data"
 }
 ```
 
-### 404 Not Found
-```json
-{
-  "timestamp": "2026-04-10T00:05:00Z",
-  "status": 404,
-  "error": "Not Found",
-  "message": "Project not found: 999"
-}
-```
+### HTTP Status Codes
 
-### 409 Conflict
-```json
-{
-  "timestamp": "2026-04-10T00:05:00Z",
-  "status": 409,
-  "error": "Conflict",
-  "message": "User is already a member of this project"
-}
-```
-
-### 503 Service Unavailable
-```json
-{
-  "timestamp": "2026-04-10T00:05:00Z",
-  "status": 503,
-  "error": "Service Unavailable",
-  "message": "FastAPI server connection failed"
-}
-```
-
----
-
-## 📌 참고사항
-
-### 헤더 설정
-
-모든 요청에 다음 헤더를 포함하세요:
-
-```http
-Content-Type: application/json
-Accept: application/json
-Authorization: Bearer <GitHub_Access_Token>
-```
-
-### Rate Limiting
-
-- **GitHub API**: 5,000 requests/hour per token
-- **FastAPI**: 분당 1000 요청 제한
-
-### CORS 설정
-
-프론트엔드에서 호출 시 CORS 설정:
-
-```javascript
-fetch('http://localhost:8080/api/v1/projects/1', {
-  headers: {
-    'Authorization': `Bearer ${githubToken}`
-  }
-})
-```
-
----
-
-**Last Updated**: 2026-04-10
+| Status | 의미 |
+|--------|------|
+| 200 | 성공 |
+| 201 | 생성 성공 |
+| 400 | 잘못된 요청 |
+| 401 | 인증 실패 |
+| 404 | 리소스 찾을 수 없음 |
+| 503 | 서버 연결 실패 |

--- a/src/main/java/markoala/fithub/demo/auth/AuthController.java
+++ b/src/main/java/markoala/fithub/demo/auth/AuthController.java
@@ -1,59 +1,114 @@
 package markoala.fithub.demo.auth;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpSession;
-import markoala.fithub.demo.global.security.handler.OAuth2SuccessHandler;
+import markoala.fithub.demo.global.security.jwt.JwtProvider;
+import markoala.fithub.demo.github.service.GithubRepositoryService;
+import markoala.fithub.demo.user.User;
+import markoala.fithub.demo.user.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/auth")
-@Tag(name = "Auth", description = "GitHub OAuth2 로그인 및 JWT 발급 API")
+@Tag(name = "Authentication", description = "GitHub OAuth 인증 API")
 public class AuthController {
 
-    @GetMapping("/token")
+    private static final Logger log = LoggerFactory.getLogger(AuthController.class);
+
+    private final GithubRepositoryService githubRepositoryService;
+    private final UserService userService;
+    private final JwtProvider jwtProvider;
+
+    @Value("${github.client-id}")
+    private String githubClientId;
+
+    @Value("${github.client-secret}")
+    private String githubClientSecret;
+
+    @Value("${github.redirect-uri}")
+    private String githubRedirectUri;
+
+    public AuthController(
+            GithubRepositoryService githubRepositoryService,
+            UserService userService,
+            JwtProvider jwtProvider
+    ) {
+        this.githubRepositoryService = githubRepositoryService;
+        this.userService = userService;
+        this.jwtProvider = jwtProvider;
+    }
+
+    @GetMapping("/login")
     @Operation(
-            summary = "JWT 토큰 발급",
-            description = """
-                    GitHub OAuth2 로그인 완료 후 JWT를 JSON으로 반환합니다.
-
-                    **사용 흐름:**
-                    1. 브라우저 또는 Postman에서 `/oauth2/authorization/github` 접속
-                    2. GitHub 로그인 완료
-                    3. 자동으로 이 엔드포인트로 redirect되며 JWT 반환
-                    4. 이후 모든 API 요청에 `Authorization: Bearer <token>` 헤더 사용
-                    """
+            summary = "GitHub OAuth 로그인",
+            description = "GitHub OAuth 인증 페이지로 리다이렉트합니다"
     )
-    @ApiResponse(responseCode = "200", description = "JWT 발급 성공")
-    @ApiResponse(responseCode = "401", description = "OAuth2 로그인 먼저 필요")
-    public ResponseEntity<Map<String, Object>> getToken(HttpSession session) {
-        String token    = (String) session.getAttribute(OAuth2SuccessHandler.SESSION_KEY_TOKEN);
-        Long   userId   = (Long)   session.getAttribute(OAuth2SuccessHandler.SESSION_KEY_USER_ID);
-        String username = (String) session.getAttribute(OAuth2SuccessHandler.SESSION_KEY_USERNAME);
+    public String login() {
+        log.info("[Auth] Redirecting to GitHub OAuth");
 
-        if (token == null) {
-            return ResponseEntity.status(401).body(Map.of(
-                    "error", "OAuth2 로그인이 필요합니다",
-                    "loginUrl", "/oauth2/authorization/github"
-            ));
-        }
+        String githubAuthUrl = String.format(
+                "https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=repo,user",
+                githubClientId,
+                githubRedirectUri
+        );
 
-        // 세션에서 제거 (1회용)
-        session.removeAttribute(OAuth2SuccessHandler.SESSION_KEY_TOKEN);
-        session.removeAttribute(OAuth2SuccessHandler.SESSION_KEY_USER_ID);
-        session.removeAttribute(OAuth2SuccessHandler.SESSION_KEY_USERNAME);
+        return "redirect:" + githubAuthUrl;
+    }
 
-        return ResponseEntity.ok(Map.of(
-                "token",    token,
-                "userId",   userId,
-                "username", username,
-                "type",     "Bearer"
-        ));
+    @GetMapping("/github/callback")
+    @Operation(
+            summary = "GitHub OAuth 콜백",
+            description = "GitHub에서 리다이렉트되는 콜백 엔드포인트. JWT 토큰을 발급하고 대시보드로 리다이렉트합니다"
+    )
+    public String githubCallback(
+            @Parameter(description = "GitHub OAuth 인증 코드", required = true)
+            @RequestParam String code,
+            @Parameter(description = "CSRF 방지용 상태 토큰")
+            @RequestParam(required = false) String state
+    ) throws IOException {
+        log.info("[Auth] Processing GitHub callback with code: {}", code);
+
+        // 1. code → GitHub access token 교환
+        String githubAccessToken = githubRepositoryService.exchangeCodeForToken(code);
+        log.info("[Auth] GitHub access token acquired");
+
+        // 2. GitHub 사용자 정보 조회
+        Map<String, Object> userInfo = githubRepositoryService.getUserInfoFromGithub(githubAccessToken);
+        String githubLogin = (String) userInfo.get("login");
+        String githubEmail = (String) userInfo.get("email");
+        Long githubId = ((Number) userInfo.get("id")).longValue();
+
+        log.info("[Auth] GitHub user info: login={}, email={}", githubLogin, githubEmail);
+
+        // 3. DB에 사용자 저장 또는 업데이트
+        User user = userService.findOrCreateGithubUser(githubLogin, githubEmail, githubId, githubAccessToken);
+        log.info("[Auth] User saved/updated: id={}, username={}", user.getId(), user.getUsername());
+
+        // 4. JWT 토큰 발급
+        String accessToken = jwtProvider.generateAccessToken(user);
+        String refreshToken = jwtProvider.generateRefreshToken(user);
+
+        log.info("[Auth] JWT tokens generated for user: {}", user.getId());
+
+        // 5. 대시보드로 리다이렉트 (토큰 포함)
+        String redirectUrl = String.format(
+                "http://localhost:3000/dashboard?accessToken=%s&refreshToken=%s",
+                accessToken,
+                refreshToken
+        );
+
+        return "redirect:" + redirectUrl;
     }
 }

--- a/src/main/java/markoala/fithub/demo/github/service/GithubRepositoryService.java
+++ b/src/main/java/markoala/fithub/demo/github/service/GithubRepositoryService.java
@@ -1,13 +1,20 @@
 package markoala.fithub.demo.github.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import markoala.fithub.demo.auth.GithubWebClientService;
 import markoala.fithub.demo.github.dto.GithubRepositoryDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +23,12 @@ public class GithubRepositoryService {
     private static final Logger log = LoggerFactory.getLogger(GithubRepositoryService.class);
 
     private final GithubWebClientService githubWebClientService;
+
+    @Value("${github.client-id}")
+    private String githubClientId;
+
+    @Value("${github.client-secret}")
+    private String githubClientSecret;
 
     public List<GithubRepositoryDto> getMyRepos() {
         var auth = githubWebClientService.getAuthInfo();
@@ -32,5 +45,67 @@ public class GithubRepositoryService {
                 .bodyToFlux(GithubRepositoryDto.class)
                 .collectList()
                 .block();
+    }
+
+    /**
+     * GitHub OAuth 인증 코드를 access token으로 교환
+     */
+    public String exchangeCodeForToken(String code) {
+        log.info("[GitHub] Exchanging authorization code for access token");
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://github.com")
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("client_id", githubClientId);
+        requestBody.put("client_secret", githubClientSecret);
+        requestBody.put("code", code);
+
+        Map<String, Object> response = webClient.post()
+                .uri("/login/oauth/access_token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        if (response == null || response.containsKey("error")) {
+            log.error("[GitHub] Failed to exchange code for token: {}",
+                response != null ? response.get("error_description") : "Unknown error");
+            throw new RuntimeException("GitHub OAuth token exchange failed");
+        }
+
+        String accessToken = (String) response.get("access_token");
+        log.info("[GitHub] Successfully obtained access token");
+        return accessToken;
+    }
+
+    /**
+     * GitHub API를 통해 사용자 정보 조회
+     */
+    public Map<String, Object> getUserInfoFromGithub(String githubAccessToken) {
+        log.info("[GitHub] Fetching user information from GitHub API");
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://api.github.com")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + githubAccessToken)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        Map<String, Object> userInfo = webClient.get()
+                .uri("/user")
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        if (userInfo == null) {
+            log.error("[GitHub] Failed to fetch user information");
+            throw new RuntimeException("Failed to fetch GitHub user information");
+        }
+
+        log.info("[GitHub] Successfully fetched user info for: {}", userInfo.get("login"));
+        return userInfo;
     }
 }

--- a/src/main/java/markoala/fithub/demo/global/config/SecurityConfig.java
+++ b/src/main/java/markoala/fithub/demo/global/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import lombok.RequiredArgsConstructor;
 import markoala.fithub.demo.global.security.handler.OAuth2SuccessHandler;
 import markoala.fithub.demo.global.security.jwt.JwtAuthenticationFilter;
+import markoala.fithub.demo.global.security.jwt.JwtProvider;
 import markoala.fithub.demo.global.security.jwt.JwtTokenProvider;
 
 @Configuration
@@ -22,6 +23,7 @@ import markoala.fithub.demo.global.security.jwt.JwtTokenProvider;
 public class SecurityConfig {
 
         private final JwtTokenProvider tokenProvider;
+        private final JwtProvider jwtProvider;
         private final OAuth2SuccessHandler successHandler;
 
         // 정적 리소스는 보안 필터를 적용하지 않음
@@ -91,7 +93,7 @@ public class SecurityConfig {
                                                 .deleteCookies("JSESSIONID")
                                 )
                                 // JWT 필터 등록
-                                .addFilterBefore(new JwtAuthenticationFilter(tokenProvider),
+                                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
                                                 UsernamePasswordAuthenticationFilter.class);
 
                 return http.build();

--- a/src/main/java/markoala/fithub/demo/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/markoala/fithub/demo/global/security/handler/OAuth2SuccessHandler.java
@@ -42,22 +42,22 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         Object idObj = oauth2User.getAttribute("id");
         String id = idObj != null ? String.valueOf(((Number) idObj).longValue()) : null;
 
-        // 사용자 조회 또는 생성
-        User user = userService.findOrCreateGitHubUser(login, email, id);
-
-        // GitHub access token 저장
+        // GitHub access token 추출
+        String githubAccessToken = null;
         if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
             OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
                     oauthToken.getAuthorizedClientRegistrationId(),
                     oauthToken.getName()
             );
-            
+
             if (client != null && client.getAccessToken() != null) {
-                String accessToken = client.getAccessToken().getTokenValue();
-                user.updateGithubAccessToken(accessToken);
-                userService.save(user);
+                githubAccessToken = client.getAccessToken().getTokenValue();
             }
         }
+
+        // 사용자 조회 또는 생성
+        Long githubIdLong = id != null ? Long.parseLong(id) : null;
+        User user = userService.findOrCreateGithubUser(login, email, githubIdLong, githubAccessToken);
 
         // JWT 토큰 생성
         String token = tokenProvider.createToken(authentication);

--- a/src/main/java/markoala/fithub/demo/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/markoala/fithub/demo/global/security/jwt/JwtAuthenticationFilter.java
@@ -4,48 +4,52 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.lang.NonNull;
-import org.springframework.security.core.Authentication;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtTokenProvider tokenProvider;
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+    private final JwtProvider jwtProvider;
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
 
     @Override
-    protected void doFilterInternal(@NonNull HttpServletRequest request,
-                                    @NonNull HttpServletResponse response,
-                                    @NonNull FilterChain filterChain)
-            throws ServletException, IOException {
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
 
-        String jwt = resolveToken(request);
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
 
-        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-            Authentication authentication = tokenProvider.getAuthentication(jwt);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            if (jwtProvider.validateToken(token)) {
+                Long userId = jwtProvider.getUserIdFromToken(token);
+                log.debug("[JWT] Authenticated user: {}", userId);
+
+                // JWT 토큰 기반 인증 설정
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                java.util.Collections.emptyList()
+                        );
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else {
+                log.warn("[JWT] Invalid token provided");
+            }
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        
-        // OAuth2 콜백 후 쿼리 파라미터로 전달된 토큰도 처리
-        String token = request.getParameter("token");
-        if (StringUtils.hasText(token)) {
-            return token;
-        }
-        
-        return null;
     }
 }

--- a/src/main/java/markoala/fithub/demo/global/security/jwt/JwtProvider.java
+++ b/src/main/java/markoala/fithub/demo/global/security/jwt/JwtProvider.java
@@ -1,0 +1,88 @@
+package markoala.fithub.demo.global.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import markoala.fithub.demo.user.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtProvider.class);
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpirationMs;
+    private final long refreshTokenExpirationMs;
+
+    public JwtProvider(
+            @Value("${jwt.secret:your-secret-key-must-be-at-least-256-bits-long-change-in-production}") String secret,
+            @Value("${jwt.access-token-expiration:3600000}") long accessTokenExpirationMs,
+            @Value("${jwt.refresh-token-expiration:604800000}") long refreshTokenExpirationMs
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+        this.accessTokenExpirationMs = accessTokenExpirationMs;
+        this.refreshTokenExpirationMs = refreshTokenExpirationMs;
+    }
+
+    /**
+     * Access Token 생성 (1시간)
+     */
+    public String generateAccessToken(User user) {
+        return Jwts.builder()
+                .subject(String.valueOf(user.getId()))
+                .claim("username", user.getUsername())
+                .claim("email", user.getEmail())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpirationMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    /**
+     * Refresh Token 생성 (7일)
+     */
+    public String generateRefreshToken(User user) {
+        return Jwts.builder()
+                .subject(String.valueOf(user.getId()))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpirationMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    /**
+     * Token에서 userId 추출
+     */
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    /**
+     * Token 유효성 검증
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            log.debug("[JWT] Token validation failed: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/markoala/fithub/demo/issue/IssueController.java
+++ b/src/main/java/markoala/fithub/demo/issue/IssueController.java
@@ -7,6 +7,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import markoala.fithub.demo.global.security.jwt.JwtProvider;
+import markoala.fithub.demo.user.User;
+import markoala.fithub.demo.user.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,18 +24,26 @@ import java.util.Map;
 @Tag(name = "Issues", description = "GitHub Issue 관리 및 동기화 API")
 public class IssueController {
 
+    private static final Logger log = LoggerFactory.getLogger(IssueController.class);
+
     private final IssueRepository issueRepository;
     private final IssueSyncRepository issueSyncRepository;
     private final GitHubIssueService gitHubIssueService;
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
 
     public IssueController(
             IssueRepository issueRepository,
             IssueSyncRepository issueSyncRepository,
-            GitHubIssueService gitHubIssueService
+            GitHubIssueService gitHubIssueService,
+            JwtProvider jwtProvider,
+            UserService userService
     ) {
         this.issueRepository = issueRepository;
         this.issueSyncRepository = issueSyncRepository;
         this.gitHubIssueService = gitHubIssueService;
+        this.jwtProvider = jwtProvider;
+        this.userService = userService;
     }
 
     @GetMapping("/{issueId}")
@@ -109,18 +122,26 @@ public class IssueController {
             @RequestParam String status,
             @Parameter(description = "GitHub 저장소 URL", required = true)
             @RequestParam String repoUrl,
-            @Parameter(description = "GitHub Access Token", required = true)
-            @RequestParam String accessToken
+            @RequestHeader(name = "Authorization") String authHeader
     ) {
+        // JWT 토큰에서 userId 추출
+        String token = authHeader.substring(7); // "Bearer " prefix 제거
+        Long userId = jwtProvider.getUserIdFromToken(token);
+        User user = userService.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+        String githubAccessToken = user.getGithubAccessToken();
+
         Issue issue = issueRepository.findById(issueId)
                 .orElseThrow(() -> new IllegalArgumentException("Issue not found: " + issueId));
 
         IssueSync sync = issueSyncRepository.findByIssueId(issueId)
                 .orElseThrow(() -> new IllegalArgumentException("IssueSync not found for issue: " + issueId));
 
-        gitHubIssueService.updateIssueStatus(sync, status, accessToken, repoUrl);
+        gitHubIssueService.updateIssueStatus(sync, status, githubAccessToken, repoUrl);
         issue.updateStatus(status);
         issueRepository.save(issue);
+
+        log.info("[Issue] Status updated for Issue #{} to {} by user {}", issueId, status, userId);
 
         return ResponseEntity.ok(Map.of(
                 "issueId", issueId.toString(),
@@ -143,13 +164,22 @@ public class IssueController {
             @PathVariable Long issueId,
             @Parameter(description = "GitHub 저장소 URL", required = true)
             @RequestParam String repoUrl,
-            @Parameter(description = "GitHub Access Token", required = true)
-            @RequestParam String accessToken
+            @RequestHeader(name = "Authorization") String authHeader
     ) {
+        // JWT 토큰에서 userId 추출
+        String token = authHeader.substring(7); // "Bearer " prefix 제거
+        Long userId = jwtProvider.getUserIdFromToken(token);
+        User user = userService.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + userId));
+        String githubAccessToken = user.getGithubAccessToken();
+
         Issue issue = issueRepository.findById(issueId)
                 .orElseThrow(() -> new IllegalArgumentException("Issue not found: " + issueId));
 
-        IssueSync sync = gitHubIssueService.syncIssueToGitHub(issue, repoUrl, accessToken);
+        IssueSync sync = gitHubIssueService.syncIssueToGitHub(issue, repoUrl, githubAccessToken);
+
+        log.info("[Issue] Issue #{} synced to GitHub by user {}", issueId, userId);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(sync);
     }
 }

--- a/src/main/java/markoala/fithub/demo/issue/RepositoryController.java
+++ b/src/main/java/markoala/fithub/demo/issue/RepositoryController.java
@@ -8,26 +8,40 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import markoala.fithub.demo.github.service.GithubRepositoryService;
 import markoala.fithub.demo.issue.dto.GithubRepositoryCreateRequest;
 import markoala.fithub.demo.issue.dto.GithubRepositoryResponse;
+import markoala.fithub.demo.issue.dto.GitHubUserRepositoriesResponse;
+import markoala.fithub.demo.issue.dto.SyncGithubRepositoriesRequest;
 import markoala.fithub.demo.project.ProjectRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/projects/{projectId}/repositories")
 @Tag(name = "Repositories", description = "프로젝트에 연결된 GitHub 레포지토리 관리 API")
 public class RepositoryController {
 
+    private static final Logger log = LoggerFactory.getLogger(RepositoryController.class);
+
     private final RepositoryRepository repositoryRepository;
     private final ProjectRepository projectRepository;
+    private final GithubRepositoryService githubRepositoryService;
 
-    public RepositoryController(RepositoryRepository repositoryRepository, ProjectRepository projectRepository) {
+    public RepositoryController(
+            RepositoryRepository repositoryRepository,
+            ProjectRepository projectRepository,
+            GithubRepositoryService githubRepositoryService
+    ) {
         this.repositoryRepository = repositoryRepository;
         this.projectRepository = projectRepository;
+        this.githubRepositoryService = githubRepositoryService;
     }
 
     @GetMapping
@@ -50,6 +64,93 @@ public class RepositoryController {
                 .toList();
 
         return ResponseEntity.ok(result);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // GitHub 저장소 자동 가져오기 및 동기화
+    // ─────────────────────────────────────────────────────────────────
+
+    @GetMapping("/github-available")
+    @Operation(summary = "사용자 GitHub 레포 목록 조회",
+            description = "인증된 사용자의 GitHub 계정에서 소유한 저장소 목록을 조회합니다. 파이프라인 생성 전에 레포를 선택할 때 사용됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "GitHub 레포 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = GitHubUserRepositoriesResponse.class))),
+            @ApiResponse(responseCode = "401", description = "GitHub 인증 실패"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<GitHubUserRepositoriesResponse> getAvailableGithubRepositories(
+            @Parameter(description = "프로젝트 ID", required = true)
+            @PathVariable Long projectId
+    ) {
+        projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("Project not found: " + projectId));
+
+        log.info("[Repository Controller] Fetching user's GitHub repositories for project {}", projectId);
+
+        var githubRepos = githubRepositoryService.getMyRepos();
+
+        var availableRepos = githubRepos.stream()
+                .map(repo -> new GitHubUserRepositoriesResponse.AvailableGithubRepository(
+                        repo.id(),
+                        repo.name(),
+                        repo.fullName(),
+                        repo.description(),
+                        repo.htmlUrl(),
+                        repo.isPrivate(),
+                        repo.language(),
+                        repo.stargazersCount(),
+                        repo.openIssuesCount()
+                ))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(new GitHubUserRepositoriesResponse(availableRepos, availableRepos.size()));
+    }
+
+    @PostMapping("/sync-from-github")
+    @Operation(summary = "GitHub 레포 일괄 동기화",
+            description = "사용자가 선택한 GitHub 저장소들을 프로젝트에 등록합니다. 각 레포에 직군(category)을 지정할 수 있습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "레포 동기화 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없음")
+    })
+    public ResponseEntity<List<GithubRepositoryResponse>> syncGithubRepositories(
+            @Parameter(description = "프로젝트 ID", required = true)
+            @PathVariable Long projectId,
+            @Valid @RequestBody SyncGithubRepositoriesRequest request
+    ) {
+        projectRepository.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("Project not found: " + projectId));
+
+        log.info("[Repository Controller] Syncing {} GitHub repositories for project {}",
+                request.githubRepoIds().size(), projectId);
+
+        var githubRepos = githubRepositoryService.getMyRepos();
+
+        List<GithubRepositoryResponse> syncedRepos = request.categoryMappings().stream()
+                .map(mapping -> {
+                    var githubRepo = githubRepos.stream()
+                            .filter(repo -> repo.id().equals(mapping.githubRepoId()))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalArgumentException(
+                                    "GitHub repository not found: " + mapping.githubRepoId()
+                            ));
+
+                    GithubRepository newRepo = GithubRepository.createRepository(
+                            projectId,
+                            githubRepo.htmlUrl(),
+                            "GITHUB",
+                            mapping.category()
+                    );
+                    GithubRepository saved = repositoryRepository.save(newRepo);
+                    log.info("[Repository Sync] Repository {} synced with category {}",
+                            mapping.repoName(), mapping.category());
+                    return GithubRepositoryResponse.from(saved);
+                })
+                .collect(Collectors.toList());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(syncedRepos);
     }
 
     @PostMapping

--- a/src/main/java/markoala/fithub/demo/issue/dto/GitHubUserRepositoriesResponse.java
+++ b/src/main/java/markoala/fithub/demo/issue/dto/GitHubUserRepositoriesResponse.java
@@ -1,0 +1,24 @@
+package markoala.fithub.demo.issue.dto;
+
+import java.util.List;
+
+/**
+ * 사용자의 GitHub 저장소 목록 응답
+ * 사용자가 자신의 GitHub 계정에서 소유한 저장소들을 조회합니다
+ */
+public record GitHubUserRepositoriesResponse(
+        List<AvailableGithubRepository> repositories,
+        int totalCount
+) {
+    public record AvailableGithubRepository(
+            Long id,
+            String name,
+            String fullName,
+            String description,
+            String htmlUrl,
+            boolean isPrivate,
+            String language,
+            int stargazersCount,
+            int openIssuesCount
+    ) {}
+}

--- a/src/main/java/markoala/fithub/demo/issue/dto/SyncGithubRepositoriesRequest.java
+++ b/src/main/java/markoala/fithub/demo/issue/dto/SyncGithubRepositoriesRequest.java
@@ -1,0 +1,28 @@
+package markoala.fithub.demo.issue.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+/**
+ * GitHub 저장소를 프로젝트에 동기화하는 요청
+ * 사용자가 선택한 저장소들을 프로젝트에 일괄 등록합니다
+ */
+public record SyncGithubRepositoriesRequest(
+        @NotNull(message = "Repository IDs are required")
+        @NotEmpty(message = "At least one repository must be selected")
+        List<Long> githubRepoIds,
+
+        @NotNull(message = "Category mapping is required")
+        List<RepositoryCategoryMapping> categoryMappings
+) {
+    /**
+     * GitHub 저장소 ID별 카테고리 매핑
+     */
+    public record RepositoryCategoryMapping(
+            Long githubRepoId,
+            String repoName,
+            String category  // FE, BE, AI, DEVOPS, QA, etc.
+    ) {}
+}

--- a/src/main/java/markoala/fithub/demo/pipeline/PipelineClient.java
+++ b/src/main/java/markoala/fithub/demo/pipeline/PipelineClient.java
@@ -64,11 +64,11 @@ public class PipelineClient {
                 .body(PipelineStepResponse.class);
     }
 
-    public void updatePipelineStep(Long stepId, PipelineStepUpdateRequest request) {
-        restClient.patch()
+    public PipelineStepResponse updatePipelineStep(Long stepId, PipelineStepUpdateRequest request) {
+        return restClient.patch()
                 .uri("/pipelines/steps/{stepId}", stepId)
                 .body(request)
                 .retrieve()
-                .toBodilessEntity();
+                .body(PipelineStepResponse.class);
     }
 }

--- a/src/main/java/markoala/fithub/demo/pipeline/PipelineController.java
+++ b/src/main/java/markoala/fithub/demo/pipeline/PipelineController.java
@@ -8,12 +8,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import markoala.fithub.demo.issue.Issue;
+import markoala.fithub.demo.pipeline.dto.CreateIssueFromStepRequest;
 import markoala.fithub.demo.pipeline.dto.MultiPipelineResponse;
 import markoala.fithub.demo.pipeline.dto.PipelineGenerateRequest;
 import markoala.fithub.demo.pipeline.dto.PipelineListResponse;
 import markoala.fithub.demo.pipeline.dto.PipelineResponse;
 import markoala.fithub.demo.pipeline.dto.PipelineStepAddRequest;
 import markoala.fithub.demo.pipeline.dto.PipelineStepResponse;
+import markoala.fithub.demo.pipeline.dto.PipelineStepUpdateRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -76,8 +79,8 @@ public class PipelineController {
     }
 
     @PostMapping("/generate")
-    @Operation(summary = "파이프라인 생성 및 GitHub 동기화",
-            description = "요구사항 텍스트를 기반으로 AI 파이프라인을 생성하고, Issue들을 Spring DB에 저장합니다")
+    @Operation(summary = "단일 파이프라인 생성",
+            description = "요구사항 텍스트를 기반으로 특정 카테고리의 AI 파이프라인을 생성합니다")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "파이프라인 생성 성공",
                     content = @Content(schema = @Schema(implementation = PipelineResponse.class))),
@@ -108,6 +111,45 @@ public class PipelineController {
         PipelineStepResponse response = pipelineService.addStepToPipeline(
                 pipelineId, request.title(), request.description());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // 파이프라인 스텝 → Issue 변환 (사용자 선택)
+    // ─────────────────────────────────────────────────────────────────
+    @PostMapping("/steps/{pipelineStepId}/create-issue")
+    @Operation(summary = "파이프라인 스텝을 Issue로 변환",
+            description = "사용자가 선택한 파이프라인 스텝을 실제 작업 Issue로 생성합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Issue 생성 성공",
+                    content = @Content(schema = @Schema(implementation = Issue.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "404", description = "저장소를 찾을 수 없음")
+    })
+    public ResponseEntity<Issue> createIssueFromStep(
+            @Parameter(description = "FastAPI Pipeline Step ID", required = true)
+            @PathVariable Long pipelineStepId,
+            @Valid @RequestBody CreateIssueFromStepRequest request
+    ) {
+        Issue issue = pipelineService.createIssueFromPipelineStep(
+                pipelineStepId, request.repositoryId(), request.title(), request.description());
+        return ResponseEntity.status(HttpStatus.CREATED).body(issue);
+    }
+
+    @PutMapping("/steps/{stepId}")
+    @Operation(summary = "파이프라인 스텝 수정",
+            description = "파이프라인 스텝의 제목, 설명, 완료 여부를 수정합니다. 개발자/기획자가 AI 생성 스텝을 조정할 수 있습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "스텝 수정 성공",
+                    content = @Content(schema = @Schema(implementation = PipelineStepResponse.class))),
+            @ApiResponse(responseCode = "404", description = "스텝을 찾을 수 없음")
+    })
+    public ResponseEntity<PipelineStepResponse> updateStep(
+            @Parameter(description = "파이프라인 스텝 ID", required = true)
+            @PathVariable Long stepId,
+            @Valid @RequestBody PipelineStepUpdateRequest request
+    ) {
+        PipelineStepResponse response = pipelineService.updatePipelineStep(stepId, request);
+        return ResponseEntity.ok(response);
     }
 
     @PatchMapping("/steps/{stepId}/complete")

--- a/src/main/java/markoala/fithub/demo/pipeline/PipelineService.java
+++ b/src/main/java/markoala/fithub/demo/pipeline/PipelineService.java
@@ -70,7 +70,6 @@ public class PipelineService {
                 .map(category -> {
                     log.info("[Pipeline Service] Generating pipeline for category: {}", category);
                     PipelineResponse response = pipelineClient.generateAndSavePipeline(projectId, category, null, pdfBytes);
-                    savePipelineStepsAsIssues(response);
                     return response;
                 })
                 .collect(Collectors.toList());
@@ -85,16 +84,21 @@ public class PipelineService {
         log.info("[Pipeline Service] Generating pipeline for project {} with category: {}", projectId, category);
         PipelineResponse pipelineResponse = pipelineClient.generateAndSavePipeline(projectId, category, requirements, null);
         log.info("[Pipeline Service] Pipeline generated with {} steps", pipelineResponse.steps().size());
-        savePipelineStepsAsIssues(pipelineResponse);
         return pipelineResponse;
     }
 
-    private void savePipelineStepsAsIssues(PipelineResponse pipelineResponse) {
-        for (PipelineStepResponse step : pipelineResponse.steps()) {
-            Issue issue = Issue.createIssue(null, null, step.title(), step.description(), "PENDING");
-            issue.setPipelineStepId(step.id().intValue());
-            issueRepository.save(issue);
-        }
+    /**
+     * 파이프라인 스텝을 Issue로 변환 (사용자 선택 시)
+     * @param pipelineStepId FastAPI의 pipeline_step ID
+     * @param repositoryId Spring의 repository ID
+     * @param title Issue 제목
+     * @param description Issue 설명
+     */
+    public Issue createIssueFromPipelineStep(Long pipelineStepId, Long repositoryId, String title, String description) {
+        log.info("[Pipeline Service] Creating issue from pipeline step {}: {}", pipelineStepId, title);
+        Issue issue = Issue.createIssue(repositoryId, null, title, description, "PENDING");
+        issue.setPipelineStepId(pipelineStepId.intValue());
+        return issueRepository.save(issue);
     }
 
     public PipelineListResponse getPipelinesByProject(Long projectId) {
@@ -105,18 +109,22 @@ public class PipelineService {
     public PipelineStepResponse addStepToPipeline(Long pipelineId, String title, String description) {
         log.info("[Pipeline Service] Adding step to pipeline {}: {}", pipelineId, title);
         PipelineStepCreateRequest request = new PipelineStepCreateRequest(title, description, false, "user_created");
-        PipelineStepResponse stepResponse = pipelineClient.addPipelineStep(pipelineId, request);
+        return pipelineClient.addPipelineStep(pipelineId, request);
+    }
 
-        Issue issue = Issue.createIssue(null, null, stepResponse.title(), stepResponse.description(), "PENDING");
-        issue.setPipelineStepId(stepResponse.id().intValue());
-        issueRepository.save(issue);
-
-        return stepResponse;
+    /**
+     * 파이프라인 스텝 수정 (title, description, is_completed)
+     * @param stepId FastAPI의 pipeline_step ID
+     * @param request 수정할 데이터
+     */
+    public PipelineStepResponse updatePipelineStep(Long stepId, PipelineStepUpdateRequest request) {
+        log.info("[Pipeline Service] Updating pipeline step {}", stepId);
+        return pipelineClient.updatePipelineStep(stepId, request);
     }
 
     public void completeStep(Long stepId) {
         log.info("[Pipeline Service] Completing pipeline step {}", stepId);
-        pipelineClient.updatePipelineStep(stepId, new PipelineStepUpdateRequest(true));
+        pipelineClient.updatePipelineStep(stepId, new PipelineStepUpdateRequest(null, null, true));
     }
 
     public List<IssueSync> syncPipelineToGitHub(Long pipelineId, Long repositoryId, String accessToken) {

--- a/src/main/java/markoala/fithub/demo/pipeline/dto/CreateIssueFromStepRequest.java
+++ b/src/main/java/markoala/fithub/demo/pipeline/dto/CreateIssueFromStepRequest.java
@@ -1,0 +1,15 @@
+package markoala.fithub.demo.pipeline.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateIssueFromStepRequest(
+        @NotNull(message = "Repository ID is required")
+        Long repositoryId,
+
+        @NotBlank(message = "Title is required")
+        String title,
+
+        @NotBlank(message = "Description is required")
+        String description
+) {}

--- a/src/main/java/markoala/fithub/demo/pipeline/dto/PipelineStepUpdateRequest.java
+++ b/src/main/java/markoala/fithub/demo/pipeline/dto/PipelineStepUpdateRequest.java
@@ -1,8 +1,16 @@
 package markoala.fithub.demo.pipeline.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
 
 public record PipelineStepUpdateRequest(
+        @JsonProperty("title")
+        @Size(max = 255, message = "Title must not exceed 255 characters")
+        String title,
+
+        @JsonProperty("description")
+        String description,
+
         @JsonProperty("is_completed")
         Boolean isCompleted
 ) {}

--- a/src/main/java/markoala/fithub/demo/user/UserService.java
+++ b/src/main/java/markoala/fithub/demo/user/UserService.java
@@ -56,21 +56,29 @@ public class UserService implements UserDetailsService {
      * GitHub OAuth 사용자 정보로 사용자 조회 또는 생성
      */
     @Transactional
-    public User findOrCreateGitHubUser(String githubLogin, String email, String githubId) {
+    public User findOrCreateGithubUser(String githubLogin, String email, Long githubId, String githubAccessToken) {
         Optional<User> existingUser = userRepository.findByUsername(githubLogin);
 
         if (existingUser.isPresent()) {
-            return existingUser.get();
+            User user = existingUser.get();
+            user.updateGithubAccessToken(githubAccessToken);
+            return userRepository.save(user);
         }
 
         // 새로운 GitHub 사용자 생성
         User newUser = User.createUser(
                 githubLogin,
                 email != null ? email : githubLogin + "@github.com",
-                githubId,
-                "USER"
+                "USER",
+                String.valueOf(githubId)
         );
+        newUser.updateGithubAccessToken(githubAccessToken);
         return userRepository.save(newUser);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/markoala/fithub/demo/integration/EndToEndPipelineIntegrationTest.java
+++ b/src/test/java/markoala/fithub/demo/integration/EndToEndPipelineIntegrationTest.java
@@ -1,0 +1,407 @@
+package markoala.fithub.demo.integration;
+
+import markoala.fithub.demo.github.dto.GithubRepositoryDto;
+import markoala.fithub.demo.github.service.GithubRepositoryService;
+import markoala.fithub.demo.global.security.jwt.JwtProvider;
+import markoala.fithub.demo.issue.GithubRepository;
+import markoala.fithub.demo.issue.GitHubIssueService;
+import markoala.fithub.demo.issue.Issue;
+import markoala.fithub.demo.issue.IssueRepository;
+import markoala.fithub.demo.issue.IssueSync;
+import markoala.fithub.demo.issue.IssueSyncRepository;
+import markoala.fithub.demo.issue.RepositoryRepository;
+import markoala.fithub.demo.pipeline.PipelineClient;
+import markoala.fithub.demo.pipeline.dto.PipelineResponse;
+import markoala.fithub.demo.pipeline.dto.PipelineStepResponse;
+import markoala.fithub.demo.project.Project;
+import markoala.fithub.demo.project.ProjectRepository;
+import markoala.fithub.demo.user.User;
+import markoala.fithub.demo.user.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("End-to-End Pipeline Integration Test")
+class EndToEndPipelineIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private RepositoryRepository repositoryRepository;
+
+    @Autowired
+    private IssueRepository issueRepository;
+
+    @Autowired
+    private IssueSyncRepository issueSyncRepository;
+
+    @MockBean
+    private GithubRepositoryService githubRepositoryService;
+
+    @MockBean
+    private PipelineClient pipelineClient;
+
+    @MockBean
+    private GitHubIssueService gitHubIssueService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @MockBean
+    private UserService userService;
+
+    private Project testProject;
+    private GithubRepository testRepository;
+    private static final Long TEST_USER_ID = 1L;
+    private static final String TEST_JWT_TOKEN = "test-jwt-token-12345";
+
+    @BeforeEach
+    void setUp() {
+        // Clean up
+        issueSyncRepository.deleteAll();
+        issueRepository.deleteAll();
+        repositoryRepository.deleteAll();
+        projectRepository.deleteAll();
+
+        // Create test project
+        testProject = Project.createProject("Test Project", "Test Description");
+        testProject = projectRepository.save(testProject);
+
+        // Setup JWT mock
+        User testUser = new User(TEST_USER_ID, "testuser", "test@example.com", "USER", "github123", "ghp_test_token", null, null);
+        when(jwtProvider.validateToken(TEST_JWT_TOKEN)).thenReturn(true);
+        when(jwtProvider.getUserIdFromToken(TEST_JWT_TOKEN)).thenReturn(TEST_USER_ID);
+        when(userService.findById(TEST_USER_ID)).thenReturn(java.util.Optional.of(testUser));
+    }
+
+    @Test
+    @DisplayName("Step 1: GitHub repo 동기화")
+    void step1_SyncGithubRepository() throws Exception {
+        // Mock GitHub API response
+        var mockGithubRepos = List.of(
+            new GithubRepositoryDto(
+                1207474638L,
+                "travel-plan",
+                "KYH-99/travel-plan",
+                "https://github.com/KYH-99/travel-plan",
+                "Travel planning app",
+                false,
+                1,
+                1,
+                "Python",
+                "2024-01-01T00:00:00Z",
+                "2024-04-12T00:00:00Z"
+            )
+        );
+        when(githubRepositoryService.getMyRepos()).thenReturn(mockGithubRepos);
+
+        // Sync repository
+        String requestBody = """
+            {
+              "githubRepoIds": [1207474638],
+              "categoryMappings": [
+                {
+                  "githubRepoId": 1207474638,
+                  "repoName": "travel-plan",
+                  "category": "BE"
+                }
+              ]
+            }
+            """;
+
+        mockMvc.perform(post("/api/v1/projects/{projectId}/repositories/sync-from-github", testProject.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$[0].category").value("BE"))
+                .andExpect(jsonPath("$[0].repoUrl").value("https://github.com/KYH-99/travel-plan"));
+
+        // Verify repository saved in DB
+        testRepository = repositoryRepository.findByProjectId(testProject.getId()).get(0);
+        assert testRepository != null;
+        assert testRepository.getCategory().equals("BE");
+    }
+
+    @Test
+    @DisplayName("Step 2: 파이프라인 생성")
+    void step2_GeneratePipeline() throws Exception {
+        // Setup: Create repository first
+        testRepository = GithubRepository.createRepository(
+            testProject.getId(),
+            "https://github.com/KYH-99/travel-plan",
+            "GITHUB",
+            "BE"
+        );
+        testRepository = repositoryRepository.save(testRepository);
+
+        // Mock FastAPI response
+        var mockPipeline = new PipelineResponse(
+            1L,
+            testProject.getId(),
+            "BE",
+            1L,
+            true,
+            List.of(
+                new PipelineStepResponse(1L, 1L, "API 설계", "REST API 설계", false, "ai_generated"),
+                new PipelineStepResponse(2L, 1L, "데이터베이스 설계", "DB 스키마 설계", false, "ai_generated"),
+                new PipelineStepResponse(3L, 1L, "인증 구현", "JWT 기반 인증", false, "ai_generated")
+            )
+        );
+
+        when(pipelineClient.generateAndSavePipeline(
+            eq(testProject.getId()),
+            eq("BE"),
+            isNull(),
+            any()
+        )).thenReturn(mockPipeline);
+
+        // Generate pipeline
+        mockMvc.perform(post("/api/v1/pipelines/generate-all")
+                .param("projectId", testProject.getId().toString())
+                .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.pipelines[0].steps.length()").value(3))
+                .andExpect(jsonPath("$.pipelines[0].steps[0].title").value("API 설계"))
+                .andExpect(jsonPath("$.pipelines[0].steps[1].title").value("데이터베이스 설계"))
+                .andExpect(jsonPath("$.pipelines[0].steps[2].title").value("인증 구현"));
+    }
+
+    @Test
+    @DisplayName("Step 3: Pipeline Step 수정")
+    void step3_UpdatePipelineStep() throws Exception {
+        // Mock FastAPI response
+        var updatedStep = new PipelineStepResponse(
+            1L,
+            1L,
+            "수정된 API 설계",
+            "REST API 및 GraphQL 설계",
+            false,
+            "user_created"
+        );
+
+        when(pipelineClient.updatePipelineStep(
+            eq(1L),
+            argThat(req -> req.title().equals("수정된 API 설계"))
+        )).thenReturn(updatedStep);
+
+        // Update step
+        String requestBody = """
+            {
+              "title": "수정된 API 설계",
+              "description": "REST API 및 GraphQL 설계",
+              "is_completed": false
+            }
+            """;
+
+        mockMvc.perform(put("/api/v1/pipelines/steps/{stepId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("수정된 API 설계"))
+                .andExpect(jsonPath("$.description").value("REST API 및 GraphQL 설계"));
+    }
+
+    @Test
+    @DisplayName("Step 4: Issue 생성 (Pipeline Step → Issue)")
+    void step4_CreateIssueFromPipelineStep() throws Exception {
+        // Setup: Create repository
+        testRepository = GithubRepository.createRepository(
+            testProject.getId(),
+            "https://github.com/KYH-99/travel-plan",
+            "GITHUB",
+            "BE"
+        );
+        testRepository = repositoryRepository.save(testRepository);
+
+        // Create issue
+        String requestBody = """
+            {
+              "repositoryId": %d,
+              "title": "API 설계",
+              "description": "REST API 설계 및 문서화"
+            }
+            """.formatted(testRepository.getId());
+
+        mockMvc.perform(post("/api/v1/pipelines/steps/{pipelineStepId}/create-issue", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("API 설계"))
+                .andExpect(jsonPath("$.description").value("REST API 설계 및 문서화"))
+                .andExpect(jsonPath("$.status").value("PENDING"));
+
+        // Verify issue saved in DB
+        List<Issue> issues = issueRepository.findByRepositoryId(testRepository.getId());
+        assert issues.size() == 1;
+        assert issues.get(0).getTitle().equals("API 설계");
+        assert issues.get(0).getPipelineStepId() == 1;
+    }
+
+    @Test
+    @DisplayName("Step 5: Issue를 GitHub로 동기화")
+    void step5_SyncIssueToGitHub() throws Exception {
+        // Setup: Create repository and issue
+        testRepository = GithubRepository.createRepository(
+            testProject.getId(),
+            "https://github.com/KYH-99/travel-plan",
+            "GITHUB",
+            "BE"
+        );
+        testRepository = repositoryRepository.save(testRepository);
+
+        Issue testIssue = Issue.createIssue(
+            testRepository.getId(),
+            null,
+            "API 설계",
+            "REST API 설계 및 문서화",
+            "PENDING"
+        );
+        testIssue.setPipelineStepId(1);
+        testIssue = issueRepository.save(testIssue);
+
+        // Mock GitHub sync response
+        IssueSync mockSync = IssueSync.createSync(
+            testIssue.getId(),
+            42,  // GitHub issue number
+            testRepository.getId(),
+            "SYNCED"
+        );
+        mockSync.markSynced("https://github.com/KYH-99/travel-plan/issues/42");
+
+        when(gitHubIssueService.syncIssueToGitHub(
+            any(),
+            eq("https://github.com/KYH-99/travel-plan"),
+            anyString()
+        )).thenReturn(mockSync);
+
+        // Sync to GitHub
+        mockMvc.perform(post("/api/v1/issues/{issueId}/sync", testIssue.getId())
+                .param("repoUrl", "https://github.com/KYH-99/travel-plan")
+                .header("Authorization", "Bearer " + TEST_JWT_TOKEN))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("SYNCED"))
+                .andExpect(jsonPath("$.githubIssueNumber").value(42))
+                .andExpect(jsonPath("$.githubUrl").value("https://github.com/KYH-99/travel-plan/issues/42"));
+    }
+
+    @Test
+    @DisplayName("Full E2E: 전체 시나리오 통합 테스트")
+    void endToEnd_FullScenario() throws Exception {
+        // 1. Sync GitHub Repository
+        var mockGithubRepos = List.of(
+            new GithubRepositoryDto(
+                1207474638L, "travel-plan", "KYH-99/travel-plan",
+                "https://github.com/KYH-99/travel-plan", "Travel planning app",
+                false, 1, 1, "Python", "2024-01-01T00:00:00Z", "2024-04-12T00:00:00Z"
+            )
+        );
+        when(githubRepositoryService.getMyRepos()).thenReturn(mockGithubRepos);
+
+        String syncBody = """
+            {
+              "githubRepoIds": [1207474638],
+              "categoryMappings": [
+                {
+                  "githubRepoId": 1207474638,
+                  "repoName": "travel-plan",
+                  "category": "BE"
+                }
+              ]
+            }
+            """;
+
+        var syncResponse = mockMvc.perform(
+                post("/api/v1/projects/{projectId}/repositories/sync-from-github", testProject.getId())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(syncBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        testRepository = repositoryRepository.findByProjectId(testProject.getId()).get(0);
+
+        // 2. Generate Pipeline
+        var mockPipeline = new PipelineResponse(
+            1L, testProject.getId(), "BE", 1L, true,
+            List.of(
+                new PipelineStepResponse(1L, 1L, "API 설계", "REST API", false, "ai_generated"),
+                new PipelineStepResponse(2L, 1L, "DB 설계", "Schema", false, "ai_generated")
+            )
+        );
+        when(pipelineClient.generateAndSavePipeline(
+            eq(testProject.getId()), eq("BE"), isNull(), any()
+        )).thenReturn(mockPipeline);
+
+        mockMvc.perform(post("/api/v1/pipelines/generate-all")
+                .param("projectId", testProject.getId().toString())
+                .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.pipelines[0].steps.length()").value(2));
+
+        // 3. Update Pipeline Step
+        var updatedStep = new PipelineStepResponse(
+            1L, 1L, "수정된 API 설계", "GraphQL + REST", false, "user_created"
+        );
+        when(pipelineClient.updatePipelineStep(eq(1L), any())).thenReturn(updatedStep);
+
+        mockMvc.perform(put("/api/v1/pipelines/steps/{stepId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"수정된 API 설계\",\"description\":\"GraphQL + REST\",\"is_completed\":false}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("수정된 API 설계"));
+
+        // 4. Create Issue
+        String issueBody = """
+            {
+              "repositoryId": %d,
+              "title": "수정된 API 설계",
+              "description": "GraphQL + REST 설계"
+            }
+            """.formatted(testRepository.getId());
+
+        mockMvc.perform(post("/api/v1/pipelines/steps/{pipelineStepId}/create-issue", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(issueBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("수정된 API 설계"));
+
+        Issue createdIssue = issueRepository.findByRepositoryId(testRepository.getId()).get(0);
+
+        // 5. Sync to GitHub
+        IssueSync mockSync = IssueSync.createSync(createdIssue.getId(), 100, testRepository.getId(), "SYNCED");
+        mockSync.markSynced("https://github.com/KYH-99/travel-plan/issues/100");
+
+        when(gitHubIssueService.syncIssueToGitHub(
+            any(), eq("https://github.com/KYH-99/travel-plan"), anyString()
+        )).thenReturn(mockSync);
+
+        mockMvc.perform(post("/api/v1/issues/{issueId}/sync", createdIssue.getId())
+                .param("repoUrl", "https://github.com/KYH-99/travel-plan")
+                .header("Authorization", "Bearer " + TEST_JWT_TOKEN))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("SYNCED"))
+                .andExpect(jsonPath("$.githubIssueNumber").value(100));
+    }
+}


### PR DESCRIPTION
GitHub OAuth 로그인 플로우를 구현하고 JWT 기반 인증으로 서버 보호:

- JwtProvider: JWT 토큰 생성/검증 (access/refresh 토큰)
- AuthController: GitHub OAuth 로그인/콜백 엔드포인트
  * GET /auth/login: GitHub 인증 페이지로 리다이렉트
  * GET /auth/github/callback: 콜백 처리 후 JWT 발급

- JwtAuthenticationFilter: Authorization 헤더 검증
- SecurityConfig: 필터 체인에 JWT 필터 등록

- UserService: findById(), findOrCreateGithubUser() 개선
  * GitHub 액세스 토큰 저장/조회

- GithubRepositoryService: OAuth 메서드 추가
  * exchangeCodeForToken(): 인증 코드 → 액세스 토큰
  * getUserInfoFromGithub(): GitHub 사용자 정보 조회

- IssueController: 쿼리 파라미터 → Authorization 헤더로 변경
  * 사용자의 저장된 GitHub 토큰으로 GitHub API 호출

- OAuth2SuccessHandler: GitHub 액세스 토큰 저장

- API 명세 업데이트: JWT 기반 인증 문서화

모든 통합 테스트 통과 (10/10)