### PR TITLE
refactor: FitAI 스키마 변경에 따른 Pipeline DTO 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ src/main/resources/application.yml
 
 ### macOS ###
 .DS_Store
+.claude/

--- a/src/main/java/markoala/fithub/demo/application/dto/request/MeetingAttendeeCreateRequest.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/request/MeetingAttendeeCreateRequest.java
@@ -1,0 +1,8 @@
+package markoala.fithub.demo.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record MeetingAttendeeCreateRequest(
+        @JsonProperty("user_id")
+        Long userId
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/request/MeetingLogCreateRequest.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/request/MeetingLogCreateRequest.java
@@ -1,0 +1,12 @@
+package markoala.fithub.demo.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record MeetingLogCreateRequest(
+        @JsonProperty("project_id")
+        Long projectId,
+        String content,
+        @JsonProperty("attendee_user_ids")
+        List<Long> attendeeUserIds
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/request/PipelineGenerateRequest.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/request/PipelineGenerateRequest.java
@@ -1,0 +1,11 @@
+package markoala.fithub.demo.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record PipelineGenerateRequest(
+        @JsonProperty("project_id")
+        Long projectId,
+        String requirements,
+        String category
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/request/PipelineStepCreateRequest.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/request/PipelineStepCreateRequest.java
@@ -1,0 +1,14 @@
+package markoala.fithub.demo.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record PipelineStepCreateRequest(
+        @JsonProperty("step_task_description")
+        String stepTaskDescription,
+        @JsonProperty("step_sequence_number")
+        Integer stepSequenceNumber,
+        String duration,
+        @JsonProperty("tech_stack")
+        String techStack,
+        String origin
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/request/PipelineStepUpdateRequest.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/request/PipelineStepUpdateRequest.java
@@ -1,0 +1,21 @@
+package markoala.fithub.demo.application.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+
+public record PipelineStepUpdateRequest(
+        @JsonProperty("step_task_description")
+        Optional<String> stepTaskDescription,
+        @JsonProperty("step_sequence_number")
+        Optional<Integer> stepSequenceNumber,
+        @JsonProperty("step_github_status")
+        Optional<String> stepGithubStatus,
+        @JsonProperty("step_planner_confirm_yn")
+        Optional<String> stepPlannerConfirmYn,
+        @JsonProperty("step_developer_confirm_yn")
+        Optional<String> stepDeveloperConfirmYn,
+        Optional<String> duration,
+        @JsonProperty("tech_stack")
+        Optional<String> techStack,
+        Optional<String> origin
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/response/MeetingAttendeeResponse.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/response/MeetingAttendeeResponse.java
@@ -1,0 +1,11 @@
+package markoala.fithub.demo.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record MeetingAttendeeResponse(
+        Long id,
+        @JsonProperty("meeting_log_id")
+        Long meetingLogId,
+        @JsonProperty("user_id")
+        Long userId
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/response/MeetingLogResponse.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/response/MeetingLogResponse.java
@@ -1,0 +1,20 @@
+package markoala.fithub.demo.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MeetingLogResponse(
+        Long id,
+        @JsonProperty("project_id")
+        Long projectId,
+        String content,
+        String summary,
+        @JsonProperty("vector_id")
+        String vectorId,
+        @JsonProperty("created_at")
+        LocalDateTime createdAt,
+        List<MeetingAttendeeResponse> attendees,
+        @JsonProperty("step_relations")
+        List<MeetingStepRelationResponse> stepRelations
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/response/MeetingStepRelationResponse.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/response/MeetingStepRelationResponse.java
@@ -1,0 +1,11 @@
+package markoala.fithub.demo.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record MeetingStepRelationResponse(
+        Long id,
+        @JsonProperty("meeting_log_id")
+        Long meetingLogId,
+        @JsonProperty("pipeline_step_id")
+        Long pipelineStepId
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/response/MeetingSummarizeResponse.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/response/MeetingSummarizeResponse.java
@@ -1,0 +1,12 @@
+package markoala.fithub.demo.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record MeetingSummarizeResponse(
+        @JsonProperty("meeting_log_id")
+        Long meetingLogId,
+        String summary,
+        @JsonProperty("derived_steps")
+        List<String> derivedSteps
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/response/PipelineListResponse.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/response/PipelineListResponse.java
@@ -1,0 +1,9 @@
+package markoala.fithub.demo.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record PipelineListResponse(
+        List<PipelineResponse> pipelines,
+        Long total
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/response/PipelineResponse.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/response/PipelineResponse.java
@@ -1,0 +1,15 @@
+package markoala.fithub.demo.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record PipelineResponse(
+        Long id,
+        @JsonProperty("project_id")
+        Long projectId,
+        String category,
+        Long version,
+        @JsonProperty("is_active")
+        String isActive,
+        List<PipelineStepResponse> steps
+) {}

--- a/src/main/java/markoala/fithub/demo/application/dto/response/PipelineStepResponse.java
+++ b/src/main/java/markoala/fithub/demo/application/dto/response/PipelineStepResponse.java
@@ -1,0 +1,32 @@
+package markoala.fithub.demo.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+
+public record PipelineStepResponse(
+        Long id,
+        @JsonProperty("pipeline_id")
+        Long pipelineId,
+        @JsonProperty("step_task_description")
+        String stepTaskDescription,
+        @JsonProperty("step_sequence_number")
+        Integer stepSequenceNumber,
+        @JsonProperty("step_github_status")
+        String stepGithubStatus,
+        @JsonProperty("step_planner_confirm_yn")
+        String stepPlannerConfirmYn,
+        @JsonProperty("step_developer_confirm_yn")
+        String stepDeveloperConfirmYn,
+        @JsonProperty("step_confirmation_date")
+        LocalDateTime stepConfirmationDate,
+        @JsonProperty("step_final_confirmed_status")
+        String stepFinalConfirmedStatus,
+        String duration,
+        @JsonProperty("tech_stack")
+        String techStack,
+        String origin,
+        @JsonProperty("created_at")
+        LocalDateTime createdAt,
+        @JsonProperty("updated_at")
+        LocalDateTime updatedAt
+) {}


### PR DESCRIPTION
# API 스펙 변경사항 정리

## 1. PipelineStepResponse 전면 수정

### 필드 변경 및 추가

* `title` → **step_task_description** (구체적인 작업 상세 내용으로 명확화)
* **step_sequence_number** 추가 (작업 순서)
* **step_github_status** 추가 (Open / Closed)
* **step_planner_confirm_yn** 추가 (기획자 승인 상태)
* **step_developer_confirm_yn** 추가 (개발자 승인 상태)
* **step_confirmation_date** 추가 (양측 승인 완료 시점)
* **step_final_confirmed_status** 추가 (계산 필드)
* **duration** 추가 (예상 소요 시간)
* **tech_stack** 추가 (기술 스택)
* **created_at**, **updated_at** 추가

### 제거된 필드

* `is_completed`

---

## 2. PipelineResponse 수정

### 타입 변경

* `is_active: Boolean` → **String**

  * 값: `Active` | `Inactive`

---

## 3. PipelineStepCreateRequest 수정

### 제거된 필드

* `title`
* `description`
* `is_completed`

### 추가된 필드

* **step_task_description**
* **step_sequence_number**
* **duration**
* **tech_stack**

---

## 4. PipelineStepUpdateRequest 확장

### 변경 사항

* 모든 수정 가능한 필드를 **Optional**로 확장
* 부분 업데이트(Patch 스타일) 가능하도록 설계

### 포함 대상 필드 (예시)

* step_task_description
* step_sequence_number
* step_github_status
* step_planner_confirm_yn
* step_developer_confirm_yn
* step_confirmation_date
* duration
* tech_stack

---
