### PR TITLE
Feat : Kakao login 구현 및 직군 필드 추가

### DIFF
--- a/DB_SCHEMA_REPORT.md
+++ b/DB_SCHEMA_REPORT.md
@@ -37,6 +37,7 @@ FitHub는 **마이크로서비스 아키텍처**를 기반으로 설계되었으
 | email | VARCHAR(255) | NOT NULL, UNIQUE | 이메일 주소 |
 | role | VARCHAR(255) | NOT NULL | 사용자 역할 (USER, ADMIN) |
 | social_login_id | VARCHAR(255) | UNIQUE | GitHub ID (소셜로그인 ID) |
+| job_role | VARCHAR(255) | | 사용자 직군 (PLANNER, FRONTEND, BACKEND, AI) |
 | github_access_token | VARCHAR(1000) | | GitHub OAuth 액세스 토큰 |
 | created_at | TIMESTAMP | NOT NULL | 생성시각 (Hibernate 자동) |
 | updated_at | TIMESTAMP | | 수정시각 (Hibernate 자동) |

--- a/src/main/java/markoala/fithub/demo/auth/AuthController.java
+++ b/src/main/java/markoala/fithub/demo/auth/AuthController.java
@@ -7,6 +7,7 @@ import markoala.fithub.demo.global.security.jwt.JwtProvider;
 import markoala.fithub.demo.github.service.GithubRepositoryService;
 import markoala.fithub.demo.user.User;
 import markoala.fithub.demo.user.UserService;
+import markoala.fithub.demo.user.JobRole;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -121,11 +123,13 @@ public class AuthController {
         response.put("accessToken", accessToken);
         response.put("refreshToken", refreshToken);
         response.put("githubAccessToken", githubAccessToken);
-        response.put("user", Map.of(
-                "id", user.getId(),
-                "username", user.getUsername(),
-                "email", user.getEmail()
-        ));
+        
+        Map<String, Object> userMap = new HashMap<>();
+        userMap.put("id", user.getId());
+        userMap.put("username", user.getUsername());
+        userMap.put("email", user.getEmail() != null ? user.getEmail() : "");
+        userMap.put("jobRole", user.getJobRole() != null ? user.getJobRole().name() : "");
+        response.put("user", userMap);
 
         log.info("[Auth] OAuth callback completed. Tokens issued for user: {}", user.getId());
 
@@ -194,11 +198,13 @@ public class AuthController {
         response.put("accessToken", accessToken);
         response.put("refreshToken", refreshToken);
         response.put("kakaoAccessToken", kakaoAccessToken);
-        response.put("user", Map.of(
-                "id", user.getId(),
-                "username", user.getUsername(),
-                "email", user.getEmail()
-        ));
+        
+        Map<String, Object> userMap = new HashMap<>();
+        userMap.put("id", user.getId());
+        userMap.put("username", user.getUsername());
+        userMap.put("email", user.getEmail() != null ? user.getEmail() : "");
+        userMap.put("jobRole", user.getJobRole() != null ? user.getJobRole().name() : "");
+        response.put("user", userMap);
 
         log.info("[Auth] Kakao OAuth callback completed. Tokens issued for user: {}", user.getId());
 
@@ -215,18 +221,65 @@ public class AuthController {
         String token = (String) session.getAttribute("jwt_token");
         Long userId = (Long) session.getAttribute("user_id");
         String username = (String) session.getAttribute("username");
+        String jobRole = (String) session.getAttribute("job_role");
 
         Map<String, Object> response = new java.util.HashMap<>();
         if (token != null) {
             response.put("success", true);
             response.put("accessToken", token);
-            response.put("user", Map.of(
-                    "id", userId != null ? userId : "",
-                    "username", username != null ? username : ""
-            ));
+            
+            Map<String, Object> userMap = new java.util.HashMap<>();
+            userMap.put("id", userId != null ? userId : "");
+            userMap.put("username", username != null ? username : "");
+            userMap.put("jobRole", jobRole != null ? jobRole : "");
+            response.put("user", userMap);
         } else {
             response.put("success", false);
             response.put("message", "No token found in session. Please login first.");
+        }
+        return response;
+    }
+
+    @PutMapping("/user/job-role")
+    @ResponseBody
+    @Operation(
+            summary = "사용자 직군(JobRole) 설정/수정",
+            description = "로그인된 사용자의 직군(PLANNER, FRONTEND, BACKEND, AI)을 설정하거나 수정합니다."
+    )
+    public Map<String, Object> updateJobRole(
+            @Parameter(description = "설정할 직군 (PLANNER, FRONTEND, BACKEND, AI)", required = true)
+            @RequestParam JobRole jobRole,
+            org.springframework.security.core.Authentication authentication
+    ) {
+        Map<String, Object> response = new HashMap<>();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            response.put("success", false);
+            response.put("message", "User is not authenticated.");
+            return response;
+        }
+
+        String username = authentication.getName();
+        java.util.Optional<User> userOpt = userService.findByUsername(username);
+
+        if (userOpt.isEmpty()) {
+            userOpt = userService.findBySocialLoginId(username);
+        }
+
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+            userService.updateJobRole(user.getId(), jobRole);
+            response.put("success", true);
+            response.put("message", "Job role updated successfully.");
+            
+            Map<String, Object> userMap = new HashMap<>();
+            userMap.put("id", user.getId());
+            userMap.put("username", user.getUsername());
+            userMap.put("email", user.getEmail() != null ? user.getEmail() : "");
+            userMap.put("jobRole", jobRole.name());
+            response.put("user", userMap);
+        } else {
+            response.put("success", false);
+            response.put("message", "User not found.");
         }
         return response;
     }

--- a/src/main/java/markoala/fithub/demo/auth/AuthController.java
+++ b/src/main/java/markoala/fithub/demo/auth/AuthController.java
@@ -33,6 +33,7 @@ public class AuthController {
     private final GithubRepositoryService githubRepositoryService;
     private final UserService userService;
     private final JwtProvider jwtProvider;
+    private final KakaoService kakaoService;
 
     @Value("${github.client-id}")
     private String githubClientId;
@@ -43,14 +44,22 @@ public class AuthController {
     @Value("${github.redirect-uri}")
     private String githubRedirectUri;
 
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
     public AuthController(
             GithubRepositoryService githubRepositoryService,
             UserService userService,
-            JwtProvider jwtProvider
+            JwtProvider jwtProvider,
+            KakaoService kakaoService
     ) {
         this.githubRepositoryService = githubRepositoryService;
         this.userService = userService;
         this.jwtProvider = jwtProvider;
+        this.kakaoService = kakaoService;
     }
 
     @GetMapping("/login")
@@ -120,6 +129,105 @@ public class AuthController {
 
         log.info("[Auth] OAuth callback completed. Tokens issued for user: {}", user.getId());
 
+        return response;
+    }
+
+    @GetMapping("/kakao/login")
+    @Operation(
+            summary = "Kakao OAuth 로그인",
+            description = "Kakao OAuth 인증 페이지로 자동 리다이렉트합니다"
+    )
+    public String kakaoLogin() {
+        log.info("[Auth] Redirecting to Kakao OAuth");
+
+        String kakaoAuthUrl = String.format(
+                "https://kauth.kakao.com/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code",
+                kakaoClientId,
+                kakaoRedirectUri
+        );
+
+        return "redirect:" + kakaoAuthUrl;
+    }
+
+    @GetMapping("/kakao/callback")
+    @ResponseBody
+    @Operation(
+            summary = "Kakao OAuth 콜백",
+            description = "Kakao에서 리다이렉트되는 콜백 엔드포인트. JWT 토큰, Kakao Access Token을 발급합니다"
+    )
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> kakaoCallback(
+            @Parameter(description = "Kakao OAuth 인증 코드", required = true)
+            @RequestParam String code
+    ) throws IOException {
+        log.info("[Auth] Processing Kakao callback with code: {}", code);
+
+        // 1. code -> Kakao access token 교환
+        String kakaoAccessToken = kakaoService.exchangeCodeForToken(code);
+        log.info("[Auth] Kakao access token acquired");
+
+        // 2. Kakao 사용자 정보 조회
+        Map<String, Object> userInfo = kakaoService.getUserInfoFromKakao(kakaoAccessToken);
+        Long kakaoId = ((Number) userInfo.get("id")).longValue();
+
+        Map<String, Object> properties = (Map<String, Object>) userInfo.get("properties");
+        String nickname = properties != null ? (String) properties.get("nickname") : "KakaoUser_" + kakaoId;
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) userInfo.get("kakao_account");
+        String email = kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
+
+        log.info("[Auth] Kakao user info: nickname={}, email={}", nickname, email);
+
+        // 3. DB에 사용자 저장 또는 업데이트
+        User user = userService.findOrCreateKakaoUser(nickname, email, kakaoId, kakaoAccessToken);
+        log.info("[Auth] User saved/updated: id={}, username={}", user.getId(), user.getUsername());
+
+        // 4. JWT 토큰 발급
+        String accessToken = jwtProvider.generateAccessToken(user);
+        String refreshToken = jwtProvider.generateRefreshToken(user);
+
+        log.info("[Auth] JWT tokens generated for user: {}", user.getId());
+
+        // 5. 토큰 정보를 JSON으로 응답
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("accessToken", accessToken);
+        response.put("refreshToken", refreshToken);
+        response.put("kakaoAccessToken", kakaoAccessToken);
+        response.put("user", Map.of(
+                "id", user.getId(),
+                "username", user.getUsername(),
+                "email", user.getEmail()
+        ));
+
+        log.info("[Auth] Kakao OAuth callback completed. Tokens issued for user: {}", user.getId());
+
+        return response;
+    }
+
+    @GetMapping("/token")
+    @ResponseBody
+    @Operation(
+            summary = "세션에 발급된 JWT 토큰 조회",
+            description = "OAuth2 성공 후 세션에 임시 저장된 JWT 토큰을 화면에 JSON으로 반환합니다."
+    )
+    public Map<String, Object> getSessionToken(jakarta.servlet.http.HttpSession session) {
+        String token = (String) session.getAttribute("jwt_token");
+        Long userId = (Long) session.getAttribute("user_id");
+        String username = (String) session.getAttribute("username");
+
+        Map<String, Object> response = new java.util.HashMap<>();
+        if (token != null) {
+            response.put("success", true);
+            response.put("accessToken", token);
+            response.put("user", Map.of(
+                    "id", userId != null ? userId : "",
+                    "username", username != null ? username : ""
+            ));
+        } else {
+            response.put("success", false);
+            response.put("message", "No token found in session. Please login first.");
+        }
         return response;
     }
 }

--- a/src/main/java/markoala/fithub/demo/auth/KakaoService.java
+++ b/src/main/java/markoala/fithub/demo/auth/KakaoService.java
@@ -1,0 +1,98 @@
+package markoala.fithub.demo.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private static final Logger log = LoggerFactory.getLogger(KakaoService.class);
+
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${kakao.client-secret:}")
+    private String kakaoClientSecret;
+
+    @Value("${kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    /**
+     * Kakao OAuth 인증 코드를 access token으로 교환
+     */
+    public String exchangeCodeForToken(String code) {
+        log.info("[Kakao] Exchanging authorization code for access token");
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://kauth.kakao.com")
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("grant_type", "authorization_code");
+        requestBody.add("client_id", kakaoClientId);
+        if (kakaoClientSecret != null && !kakaoClientSecret.isEmpty()) {
+            requestBody.add("client_secret", kakaoClientSecret);
+        }
+        requestBody.add("redirect_uri", kakaoRedirectUri);
+        requestBody.add("code", code);
+
+        Map<String, Object> response = webClient.post()
+                .uri("/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(requestBody))
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        if (response == null || response.containsKey("error")) {
+            log.error("[Kakao] Failed to exchange code for token: {}",
+                    response != null ? response.get("error_description") : "Unknown error");
+            throw new RuntimeException("Kakao OAuth token exchange failed");
+        }
+
+        String accessToken = (String) response.get("access_token");
+        log.info("[Kakao] Successfully obtained access token");
+        return accessToken;
+    }
+
+    /**
+     * Kakao API를 통해 사용자 정보 조회
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getUserInfoFromKakao(String kakaoAccessToken) {
+        log.info("[Kakao] Fetching user information from Kakao API");
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + kakaoAccessToken)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+
+        Map<String, Object> userInfo = webClient.get()
+                .uri("/v2/user/me")
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        if (userInfo == null) {
+            log.error("[Kakao] Failed to fetch user information");
+            throw new RuntimeException("Failed to fetch Kakao user information");
+        }
+
+        log.info("[Kakao] Successfully fetched user info with id: {}", userInfo.get("id"));
+        return userInfo;
+    }
+}

--- a/src/main/java/markoala/fithub/demo/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/markoala/fithub/demo/global/security/handler/OAuth2SuccessHandler.java
@@ -25,49 +25,97 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     public static final String SESSION_KEY_USER_ID = "user_id";
     public static final String SESSION_KEY_USERNAME = "username";
 
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(OAuth2SuccessHandler.class);
+
     private final JwtTokenProvider tokenProvider;
     private final UserService userService;
     private final OAuth2AuthorizedClientService authorizedClientService;
 
     @Override
+    @SuppressWarnings("unchecked")
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
-
-        // OAuth2User 정보 추출
-        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
-        String login = (String) oauth2User.getAttribute("login");
-        String email = (String) oauth2User.getAttribute("email");
-        
-        // GitHub ID는 Integer로 반환되므로 Long으로 변환 후 String으로
-        Object idObj = oauth2User.getAttribute("id");
-        String id = idObj != null ? String.valueOf(((Number) idObj).longValue()) : null;
-
-        // GitHub access token 추출
-        String githubAccessToken = null;
-        if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
-            OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
-                    oauthToken.getAuthorizedClientRegistrationId(),
-                    oauthToken.getName()
-            );
-
-            if (client != null && client.getAccessToken() != null) {
-                githubAccessToken = client.getAccessToken().getTokenValue();
+        try {
+            log.info("[OAuth2SuccessHandler] Authentication success callback triggered");
+            
+            // OAuth2User 정보 추출
+            OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+            log.info("[OAuth2SuccessHandler] OAuth2User attributes: {}", oauth2User.getAttributes());
+            
+            String provider = "github";
+            if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
+                provider = oauthToken.getAuthorizedClientRegistrationId();
             }
+            log.info("[OAuth2SuccessHandler] Detected OAuth provider: {}", provider);
+
+            String login = null;
+            String email = null;
+            String socialLoginId = null;
+            String accessToken = null;
+
+            // access token 추출
+            if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
+                OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
+                        oauthToken.getAuthorizedClientRegistrationId(),
+                        oauthToken.getName()
+                );
+
+                if (client != null && client.getAccessToken() != null) {
+                    accessToken = client.getAccessToken().getTokenValue();
+                }
+            }
+
+            User user;
+
+            if ("kakao".equalsIgnoreCase(provider)) {
+                // Kakao attributes
+                Object idObj = oauth2User.getAttribute("id");
+                socialLoginId = idObj != null ? String.valueOf(idObj) : null;
+
+                java.util.Map<String, Object> properties = (java.util.Map<String, Object>) oauth2User.getAttribute("properties");
+                if (properties != null) {
+                    login = (String) properties.get("nickname");
+                }
+
+                java.util.Map<String, Object> kakaoAccount = (java.util.Map<String, Object>) oauth2User.getAttribute("kakao_account");
+                if (kakaoAccount != null) {
+                    email = (String) kakaoAccount.get("email");
+                }
+
+                log.info("[OAuth2SuccessHandler] Parsed Kakao credentials: id={}, login={}, email={}", socialLoginId, login, email);
+
+                Long kakaoIdLong = socialLoginId != null ? Long.parseLong(socialLoginId) : null;
+                user = userService.findOrCreateKakaoUser(login, email, kakaoIdLong, accessToken);
+            } else {
+                // GitHub attributes
+                login = (String) oauth2User.getAttribute("login");
+                email = (String) oauth2User.getAttribute("email");
+                Object idObj = oauth2User.getAttribute("id");
+                socialLoginId = idObj != null ? String.valueOf(((Number) idObj).longValue()) : null;
+
+                log.info("[OAuth2SuccessHandler] Parsed GitHub credentials: id={}, login={}, email={}", socialLoginId, login, email);
+
+                Long githubIdLong = socialLoginId != null ? Long.parseLong(socialLoginId) : null;
+                user = userService.findOrCreateGithubUser(login, email, githubIdLong, accessToken);
+            }
+
+            log.info("[OAuth2SuccessHandler] User retrieval/creation succeeded. user_id: {}", user.getId());
+
+            // JWT 토큰 생성
+            String token = tokenProvider.createToken(authentication);
+
+            // JWT를 세션에 저장 후 /api/v1/auth/token 으로 리다이렉트
+            HttpSession session = request.getSession();
+            session.setAttribute(SESSION_KEY_TOKEN, token);
+            session.setAttribute(SESSION_KEY_USER_ID, user.getId());
+            session.setAttribute(SESSION_KEY_USERNAME, user.getUsername());
+
+            log.info("[OAuth2SuccessHandler] Session JWT successfully created and stored. Redirecting to /api/v1/auth/token");
+            getRedirectStrategy().sendRedirect(request, response, "/api/v1/auth/token");
+
+        } catch (Exception e) {
+            log.error("[OAuth2SuccessHandler] CRITICAL ERROR: Failed to process OAuth2 authentication success!", e);
+            throw new RuntimeException("OAuth2 Success Handler processing failed", e);
         }
-
-        // 사용자 조회 또는 생성
-        Long githubIdLong = id != null ? Long.parseLong(id) : null;
-        User user = userService.findOrCreateGithubUser(login, email, githubIdLong, githubAccessToken);
-
-        // JWT 토큰 생성
-        String token = tokenProvider.createToken(authentication);
-
-        // JWT를 세션에 저장 후 /api/v1/auth/token 으로 리다이렉트
-        HttpSession session = request.getSession();
-        session.setAttribute(SESSION_KEY_TOKEN, token);
-        session.setAttribute(SESSION_KEY_USER_ID, user.getId());
-        session.setAttribute(SESSION_KEY_USERNAME, user.getUsername());
-
-        getRedirectStrategy().sendRedirect(request, response, "/api/v1/auth/token");
     }
 }

--- a/src/main/java/markoala/fithub/demo/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/markoala/fithub/demo/global/security/handler/OAuth2SuccessHandler.java
@@ -109,6 +109,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             session.setAttribute(SESSION_KEY_TOKEN, token);
             session.setAttribute(SESSION_KEY_USER_ID, user.getId());
             session.setAttribute(SESSION_KEY_USERNAME, user.getUsername());
+            session.setAttribute("job_role", user.getJobRole() != null ? user.getJobRole().name() : "");
 
             log.info("[OAuth2SuccessHandler] Session JWT successfully created and stored. Redirecting to /api/v1/auth/token");
             getRedirectStrategy().sendRedirect(request, response, "/api/v1/auth/token");

--- a/src/main/java/markoala/fithub/demo/user/JobRole.java
+++ b/src/main/java/markoala/fithub/demo/user/JobRole.java
@@ -1,0 +1,8 @@
+package markoala.fithub.demo.user;
+
+public enum JobRole {
+    PLANNER,
+    FRONTEND,
+    BACKEND,
+    AI
+}

--- a/src/main/java/markoala/fithub/demo/user/User.java
+++ b/src/main/java/markoala/fithub/demo/user/User.java
@@ -26,6 +26,10 @@ public class User {
     @Column(name = "social_login_id", unique = true)
     private String socialLoginId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "job_role")
+    private JobRole jobRole;
+
     @Column(name = "github_access_token")
     private String githubAccessToken;
 
@@ -70,6 +74,10 @@ public class User {
         return socialLoginId;
     }
 
+    public JobRole getJobRole() {
+        return jobRole;
+    }
+
     public String getGithubAccessToken() {
         return githubAccessToken;
     }
@@ -96,5 +104,9 @@ public class User {
 
     public void updateGithubAccessToken(String newGithubAccessToken) {
         this.githubAccessToken = newGithubAccessToken;
+    }
+
+    public void updateJobRole(JobRole newJobRole) {
+        this.jobRole = newJobRole;
     }
 }

--- a/src/main/java/markoala/fithub/demo/user/UserService.java
+++ b/src/main/java/markoala/fithub/demo/user/UserService.java
@@ -123,4 +123,12 @@ public class UserService implements UserDetailsService {
     public User save(User user) {
         return userRepository.save(user);
     }
+
+    @Transactional
+    public User updateJobRole(Long id, JobRole jobRole) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("User not found for id: " + id));
+        user.updateJobRole(jobRole);
+        return userRepository.save(user);
+    }
 }

--- a/src/main/java/markoala/fithub/demo/user/UserService.java
+++ b/src/main/java/markoala/fithub/demo/user/UserService.java
@@ -76,6 +76,34 @@ public class UserService implements UserDetailsService {
         return userRepository.save(newUser);
     }
 
+    /**
+     * Kakao OAuth 사용자 정보로 사용자 조회 또는 생성
+     */
+    @Transactional
+    public User findOrCreateKakaoUser(String nickname, String email, Long kakaoId, String kakaoAccessToken) {
+        String socialLoginId = String.valueOf(kakaoId);
+        Optional<User> existingUser = userRepository.findBySocialLoginId(socialLoginId);
+
+        if (existingUser.isPresent()) {
+            return existingUser.get();
+        }
+
+        // 중복되지 않는 고유한 username 생성
+        String username = nickname != null ? nickname : "kakao_" + socialLoginId;
+        if (userRepository.findByUsername(username).isPresent()) {
+            username = username + "_" + socialLoginId.substring(Math.max(0, socialLoginId.length() - 4));
+        }
+
+        // 새로운 Kakao 사용자 생성
+        User newUser = User.createUser(
+                username,
+                email != null ? email : socialLoginId + "@kakao.com",
+                "USER",
+                socialLoginId
+        );
+        return userRepository.save(newUser);
+    }
+
     @Transactional(readOnly = true)
     public Optional<User> findById(Long id) {
         return userRepository.findById(id);

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -2,21 +2,214 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Login</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fithub - Login</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800&display=swap" rel="stylesheet">
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+            background: radial-gradient(circle at 0% 0%, #1a1b36 0%, #0d0e15 100%);
+            color: #ffffff;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            overflow: hidden;
+            position: relative;
+        }
+
+        /* Ambient light elements in background */
+        body::before {
+            content: '';
+            position: absolute;
+            width: 350px;
+            height: 350px;
+            background: radial-gradient(circle, rgba(110, 68, 255, 0.4) 0%, rgba(0,0,0,0) 70%);
+            top: 10%;
+            left: 10%;
+            z-index: 1;
+            filter: blur(40px);
+            animation: pulse 10s ease-in-out infinite alternate;
+        }
+
+        body::after {
+            content: '';
+            position: absolute;
+            width: 400px;
+            height: 400px;
+            background: radial-gradient(circle, rgba(255, 203, 5, 0.15) 0%, rgba(0,0,0,0) 75%);
+            bottom: 10%;
+            right: 10%;
+            z-index: 1;
+            filter: blur(50px);
+            animation: pulse 8s ease-in-out infinite alternate-reverse;
+        }
+
+        @keyframes pulse {
+            0% { transform: scale(1); opacity: 0.6; }
+            100% { transform: scale(1.2); opacity: 0.9; }
+        }
+
+        .login-container {
+            background: rgba(255, 255, 255, 0.04);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 24px;
+            padding: 3rem 2.5rem;
+            width: 100%;
+            max-width: 440px;
+            text-align: center;
+            box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5),
+                        inset 0 1px 0 rgba(255, 255, 255, 0.1);
+            z-index: 10;
+            position: relative;
+            transform: translateY(0);
+            animation: floatIn 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+
+        @keyframes floatIn {
+            0% { transform: translateY(40px); opacity: 0; }
+            100% { transform: translateY(0); opacity: 1; }
+        }
+
+        .logo-area {
+            font-size: 3rem;
+            margin-bottom: 0.5rem;
+            animation: logoBounce 2s ease-in-out infinite alternate;
+            display: inline-block;
+        }
+
+        @keyframes logoBounce {
+            0% { transform: translateY(0); }
+            100% { transform: translateY(-6px); }
+        }
+
+        h2 {
+            font-size: 2.2rem;
+            font-weight: 800;
+            margin-bottom: 0.75rem;
+            background: linear-gradient(135deg, #ffffff 0%, #a5b4fc 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            letter-spacing: -0.5px;
+        }
+
+        p.subtitle {
+            color: #94a3b8;
+            font-size: 0.95rem;
+            margin-bottom: 2.5rem;
+            font-weight: 300;
+        }
+
+        .btn-oauth {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            padding: 0.9rem 1.5rem;
+            border-radius: 12px;
+            font-size: 1rem;
+            font-weight: 600;
+            text-decoration: none;
+            transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+            position: relative;
+            overflow: hidden;
+            margin-bottom: 1rem;
+            cursor: pointer;
+        }
+
+        /* GitHub Button Style */
+        .btn-github {
+            background-color: #24292f;
+            color: #ffffff;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .btn-github:hover {
+            background-color: #333942;
+            transform: translateY(-3px);
+            box-shadow: 0 10px 20px rgba(36, 41, 47, 0.4),
+                        0 0 0 2px rgba(255, 255, 255, 0.2);
+        }
+
+        .btn-github:active {
+            transform: translateY(-1px);
+        }
+
+        /* Kakao Button Style */
+        .btn-kakao {
+            background-color: #fee500;
+            color: #191919;
+            border: none;
+        }
+
+        .btn-kakao:hover {
+            background-color: #fdd835;
+            transform: translateY(-3px);
+            box-shadow: 0 10px 20px rgba(254, 229, 0, 0.3),
+                        0 0 0 2px rgba(254, 229, 0, 0.4);
+        }
+
+        .btn-kakao:active {
+            transform: translateY(-1px);
+        }
+
+        .oauth-icon {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-right: 12px;
+        }
+
+        .oauth-icon img {
+            width: 22px;
+            height: 22px;
+            object-fit: contain;
+        }
+
+        /* Subtle copyright or notice */
+        .footer-note {
+            margin-top: 2rem;
+            font-size: 0.8rem;
+            color: #64748b;
+            font-weight: 300;
+        }
+    </style>
 </head>
 <body>
 <div class="login-container">
-    <h2>Login</h2>
+    <div class="logo-area">🚀</div>
+    <h2>Fithub</h2>
+    <p class="subtitle">마르코알라와 함께 프로젝트와 이슈를 관리하세요</p>
 
     <!-- Oauth 소셜로그인 -->
-    <div class="login_github">
-        <a href="/oauth2/authorization/github">
-            <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-                 alt="GitHub Logo" width="20" style="vertical-align: middle; margin-right: 8px;">
-            👉 GitHub로 로그인
-        </a>
-    </div>
+    <a href="/oauth2/authorization/github" class="btn-oauth btn-github">
+        <div class="oauth-icon">
+            <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub Logo">
+        </div>
+        <span>GitHub로 계속하기</span>
+    </a>
+
+    <a href="/oauth2/authorization/kakao" class="btn-oauth btn-kakao">
+        <div class="oauth-icon">
+            <img src="https://developers.kakao.com/assets/img/about/logos/kakaolink/kakaolink_btn_medium.png" alt="Kakao Logo">
+        </div>
+        <span>Kakao로 계속하기</span>
+    </a>
     <!-- Oauth 소셜로그인 end -->
+
+    <div class="footer-note">
+        계정이 없으신가요? 간편 로그인으로 즉시 가입 가능합니다.
+    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
# 💛 FitHub Kakao OAuth REST API 명세서

본 문서는 프론트엔드에서 카카오 소셜 로그인을 처리하기 위해 사용되는 백엔드 API 명세서입니다.

---

## 🔌 카카오 로그인 API 목록

### 1️⃣ **카카오 로그인 창 리다이렉트**
* **Endpoint**: `GET /api/v1/auth/kakao/login`
* **Description**: 프론트엔드에서 사용자를 카카오 로그인 및 동의 화면으로 리다이렉트하기 위해 연결하는 엔드포인트입니다.
* **동작 방식**: 호출 시 아래 카카오 인가 코드 요청 주소로 사용자를 `302 Redirect` 시킵니다.
  ```http
  https://kauth.kakao.com/oauth/authorize?client_id={REST_API_KEY}&redirect_uri=http://localhost:8080/api/v1/auth/kakao/callback&response_type=code
  ```

---

### 2️⃣ **카카오 로그인 인가코드 콜백 (회원가입 및 JWT 발급)**
* **Endpoint**: `GET /api/v1/auth/kakao/callback`
* **Description**: 사용자가 카카오 로그인 동의 완료 후 리다이렉트되는 콜백 주소입니다. 전달된 인가코드로 카카오 토큰을 교환하고 백엔드 DB에 유저 정보를 동기화한 뒤 **최종 JWT 액세스 토큰**을 직접 발급합니다.
* **Query Parameters**:
  | 파라미터명 | 타입 | 필수 여부 | 설명 |
  | :--- | :--- | :--- | :--- |
  | **code** | String | 필수 | 카카오 측에서 발급하여 넘겨준 인가 코드 (Authorization Code) |

* **성공 응답 (`HTTP 200 OK`):**
  ```json
  {
    "success": true,
    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
    "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
    "kakaoAccessToken": "kakaotoken_12345abcdef...",
    "user": {
      "id": 5,
      "username": "카카오유저_12345",
      "email": "12345@kakao.com",
      "jobRole": ""  // 👈 최초 소셜 회원 가입 시에는 빈 문자열("")
    }
  }
  ```

---

### 3️⃣ **로그인 완료 후 세션 토큰 수동 조회**
* **Endpoint**: `GET /api/v1/auth/token`
* **Description**: 표준 OAuth2 브라우저 흐름을 탈 때, 서버 단에서 인증 성공 후 HTTP 세션 쿠키에 보관해 둔 JWT를 프론트엔드가 수동으로 가져갈 때 호출하는 조회 엔드포인트입니다.
* **Headers**: 필요 없음 (세션 쿠키 활용)
* **성공 응답 (`HTTP 200 OK`):**
  ```json
  {
    "success": true,
    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
    "user": {
      "id": 5,
      "username": "카카오유저_12345",
      "jobRole": ""  // 최초 가입 시 "", 직군 등록 후 "BACKEND" 등
    }
  }
  ```
