### PR TITLE
feat : 프로젝트 삭제 이벤트 및 AI 정리 반영

### DIFF
--- a/src/main/java/markoala/fithub/demo/FithubApplication.java
+++ b/src/main/java/markoala/fithub/demo/FithubApplication.java
@@ -2,7 +2,9 @@ package markoala.fithub.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class FithubApplication {
 

--- a/src/main/java/markoala/fithub/demo/domain/outbox/AiCleanupClient.java
+++ b/src/main/java/markoala/fithub/demo/domain/outbox/AiCleanupClient.java
@@ -1,0 +1,31 @@
+package markoala.fithub.demo.domain.outbox;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class AiCleanupClient {
+
+    private static final Logger log = LoggerFactory.getLogger(AiCleanupClient.class);
+
+    private final RestClient restClient;
+
+    public AiCleanupClient(@Qualifier("fastApiRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public void deleteProjectResources(Long projectId) {
+        try {
+            restClient.delete()
+                    .uri("/internal/projects/{projectId}", projectId)
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (HttpClientErrorException.NotFound e) {
+            log.info("[AI Cleanup] Project resources already absent: projectId={}", projectId);
+        }
+    }
+}

--- a/src/main/java/markoala/fithub/demo/domain/outbox/OutboxEvent.java
+++ b/src/main/java/markoala/fithub/demo/domain/outbox/OutboxEvent.java
@@ -1,0 +1,111 @@
+package markoala.fithub.demo.domain.outbox;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Getter
+@Entity
+@Table(name = "outbox_events")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OutboxEvent {
+
+    private static final int MAX_ERROR_MESSAGE_LENGTH = 1_000;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 50)
+    private OutboxEventType eventType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private OutboxEventStatus status;
+
+    @Column(name = "aggregate_id", nullable = false)
+    private Long aggregateId;
+
+    @Lob
+    @Column(nullable = false)
+    private String payload;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    @Column(name = "next_retry_at", nullable = false)
+    private LocalDateTime nextRetryAt;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    @Column(name = "error_message", length = MAX_ERROR_MESSAGE_LENGTH)
+    private String errorMessage;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    private OutboxEvent(OutboxEventType eventType, Long aggregateId, String payload) {
+        this.eventType = eventType;
+        this.aggregateId = aggregateId;
+        this.payload = payload;
+        this.status = OutboxEventStatus.PENDING;
+        this.retryCount = 0;
+        this.nextRetryAt = LocalDateTime.now();
+    }
+
+    public static OutboxEvent projectDeleted(Long projectId) {
+        return new OutboxEvent(
+                OutboxEventType.PROJECT_DELETED,
+                projectId,
+                "{\"projectId\":" + projectId + "}"
+        );
+    }
+
+    public void markProcessing() {
+        this.status = OutboxEventStatus.PROCESSING;
+        this.errorMessage = null;
+    }
+
+    public void markDone() {
+        this.status = OutboxEventStatus.DONE;
+        this.processedAt = LocalDateTime.now();
+        this.errorMessage = null;
+    }
+
+    public void markRetry(Throwable cause, int maxRetries, long delaySeconds) {
+        this.retryCount++;
+        this.errorMessage = truncate(cause.getMessage());
+        if (this.retryCount >= maxRetries) {
+            this.status = OutboxEventStatus.FAILED;
+        } else {
+            this.status = OutboxEventStatus.PENDING;
+            this.nextRetryAt = LocalDateTime.now().plusSeconds(delaySeconds);
+        }
+    }
+
+    private String truncate(String value) {
+        if (value == null || value.length() <= MAX_ERROR_MESSAGE_LENGTH) {
+            return value;
+        }
+        return value.substring(0, MAX_ERROR_MESSAGE_LENGTH);
+    }
+}

--- a/src/main/java/markoala/fithub/demo/domain/outbox/OutboxEventRepository.java
+++ b/src/main/java/markoala/fithub/demo/domain/outbox/OutboxEventRepository.java
@@ -1,0 +1,26 @@
+package markoala.fithub.demo.domain.outbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
+
+    @Query("""
+            select e
+            from OutboxEvent e
+            where e.status = :status
+              and e.nextRetryAt <= :now
+            order by e.createdAt asc
+            """)
+    List<OutboxEvent> findDueEvents(
+            @Param("status") OutboxEventStatus status,
+            @Param("now") LocalDateTime now,
+            Pageable pageable
+    );
+}

--- a/src/main/java/markoala/fithub/demo/domain/outbox/OutboxEventStatus.java
+++ b/src/main/java/markoala/fithub/demo/domain/outbox/OutboxEventStatus.java
@@ -1,0 +1,8 @@
+package markoala.fithub.demo.domain.outbox;
+
+public enum OutboxEventStatus {
+    PENDING,
+    PROCESSING,
+    DONE,
+    FAILED
+}

--- a/src/main/java/markoala/fithub/demo/domain/outbox/OutboxEventType.java
+++ b/src/main/java/markoala/fithub/demo/domain/outbox/OutboxEventType.java
@@ -1,0 +1,5 @@
+package markoala.fithub.demo.domain.outbox;
+
+public enum OutboxEventType {
+    PROJECT_DELETED
+}

--- a/src/main/java/markoala/fithub/demo/domain/outbox/OutboxWorker.java
+++ b/src/main/java/markoala/fithub/demo/domain/outbox/OutboxWorker.java
@@ -1,0 +1,69 @@
+package markoala.fithub.demo.domain.outbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxWorker {
+
+    private static final Logger log = LoggerFactory.getLogger(OutboxWorker.class);
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final AiCleanupClient aiCleanupClient;
+
+    @Value("${outbox.worker.batch-size:20}")
+    private int batchSize;
+
+    @Value("${outbox.worker.max-retries:5}")
+    private int maxRetries;
+
+    @Scheduled(fixedDelayString = "${outbox.worker.fixed-delay-ms:5000}")
+    @Transactional
+    public void processPendingEvents() {
+        List<OutboxEvent> events = outboxEventRepository.findDueEvents(
+                OutboxEventStatus.PENDING,
+                LocalDateTime.now(),
+                PageRequest.of(0, batchSize)
+        );
+
+        for (OutboxEvent event : events) {
+            processEvent(event);
+        }
+    }
+
+    private void processEvent(OutboxEvent event) {
+        event.markProcessing();
+        try {
+            if (event.getEventType() != OutboxEventType.PROJECT_DELETED) {
+                throw new IllegalStateException("Unsupported outbox event type: " + event.getEventType());
+            }
+            aiCleanupClient.deleteProjectResources(event.getAggregateId());
+            event.markDone();
+            log.info("[OutboxWorker] Processed {} for aggregateId={}", event.getEventType(), event.getAggregateId());
+        } catch (Exception e) {
+            long delaySeconds = retryDelaySeconds(event.getRetryCount() + 1);
+            event.markRetry(e, maxRetries, delaySeconds);
+            log.warn(
+                    "[OutboxWorker] Failed {} for aggregateId={}, retryCount={}, status={}",
+                    event.getEventType(),
+                    event.getAggregateId(),
+                    event.getRetryCount(),
+                    event.getStatus(),
+                    e
+            );
+        }
+    }
+
+    private long retryDelaySeconds(int nextAttempt) {
+        return Math.min(60L * nextAttempt, 3_600L);
+    }
+}

--- a/src/main/java/markoala/fithub/demo/domain/pipeline/service/PipelineV3Service.java
+++ b/src/main/java/markoala/fithub/demo/domain/pipeline/service/PipelineV3Service.java
@@ -8,16 +8,11 @@ import markoala.fithub.demo.domain.pipeline.dto.request.PipelineV3Request;
 import markoala.fithub.demo.domain.pipeline.dto.response.PipelineListResponse;
 import markoala.fithub.demo.domain.pipeline.dto.response.PipelineV3Response;
 import markoala.fithub.demo.domain.pipeline.dto.response.PipelineStepV3Response;
-import markoala.fithub.demo.domain.issue.GithubRepository;
 import markoala.fithub.demo.domain.issue.RepositoryRepository;
+import markoala.fithub.demo.domain.pipeline.dto.response.ProjectPipelineOverviewResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * v3 파이프라인 생성 서비스 계층.
@@ -44,7 +39,7 @@ public class PipelineV3Service {
     /**
      * 프로젝트 정보와 파이프라인 정보를 결합하여 반환 (API Composition)
      */
-    public markoala.fithub.demo.domain.pipeline.dto.response.ProjectPipelineOverviewResponse getProjectPipelineOverview(Long projectId) {
+    public ProjectPipelineOverviewResponse getProjectPipelineOverview(Long projectId) {
         log.info("[PipelineV3Service] Composing project-pipeline overview for project {}", projectId);
         
         // 1. Spring DB에서 프로젝트 정보 조회
@@ -55,7 +50,7 @@ public class PipelineV3Service {
         PipelineListResponse pipelineList = pipelineV3Client.getPipelinesByProject(projectId);
 
         // 3. 데이터 결합
-        return new markoala.fithub.demo.domain.pipeline.dto.response.ProjectPipelineOverviewResponse(
+        return new ProjectPipelineOverviewResponse(
                 project.getId(),
                 project.getName(),
                 project.getDescription(),

--- a/src/main/java/markoala/fithub/demo/domain/project/ProjectService.java
+++ b/src/main/java/markoala/fithub/demo/domain/project/ProjectService.java
@@ -1,5 +1,7 @@
 package markoala.fithub.demo.domain.project;
 
+import markoala.fithub.demo.domain.outbox.OutboxEvent;
+import markoala.fithub.demo.domain.outbox.OutboxEventRepository;
 import markoala.fithub.demo.domain.project.dto.ProjectCreateRequest;
 import markoala.fithub.demo.domain.project.dto.ProjectUpdateRequest;
 import markoala.fithub.demo.domain.user.JobRole;
@@ -20,6 +22,7 @@ public class ProjectService {
     private final ProjectRepository projectRepository;
     private final ProjectMemberRepository projectMemberRepository;
     private final UserRepository userRepository;
+    private final OutboxEventRepository outboxEventRepository;
 
     public Project getProject(Long projectId) {
         return projectRepository.findById(projectId)
@@ -101,6 +104,7 @@ public class ProjectService {
         projectMemberRepository.deleteAll(members);
 
         projectRepository.delete(project);
+        outboxEventRepository.save(OutboxEvent.projectDeleted(projectId));
     }
 
     @Transactional

--- a/src/test/java/markoala/fithub/demo/domain/outbox/OutboxWorkerTest.java
+++ b/src/test/java/markoala/fithub/demo/domain/outbox/OutboxWorkerTest.java
@@ -1,0 +1,75 @@
+package markoala.fithub.demo.domain.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxWorkerTest {
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    @Mock
+    private AiCleanupClient aiCleanupClient;
+
+    @InjectMocks
+    private OutboxWorker outboxWorker;
+
+    @Test
+    @DisplayName("PROJECT_DELETED 이벤트 처리 성공 시 DONE 상태로 변경")
+    void processProjectDeletedEventSuccess() {
+        OutboxEvent event = OutboxEvent.projectDeleted(1L);
+        ReflectionTestUtils.setField(outboxWorker, "batchSize", 20);
+        ReflectionTestUtils.setField(outboxWorker, "maxRetries", 5);
+
+        when(outboxEventRepository.findDueEvents(
+                eq(OutboxEventStatus.PENDING),
+                any(LocalDateTime.class),
+                any(Pageable.class)
+        )).thenReturn(List.of(event));
+
+        outboxWorker.processPendingEvents();
+
+        verify(aiCleanupClient).deleteProjectResources(1L);
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.DONE);
+        assertThat(event.getProcessedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("PROJECT_DELETED 이벤트 처리 실패 시 재시도 예약")
+    void processProjectDeletedEventFailureSchedulesRetry() {
+        OutboxEvent event = OutboxEvent.projectDeleted(1L);
+        ReflectionTestUtils.setField(outboxWorker, "batchSize", 20);
+        ReflectionTestUtils.setField(outboxWorker, "maxRetries", 5);
+
+        when(outboxEventRepository.findDueEvents(
+                eq(OutboxEventStatus.PENDING),
+                any(LocalDateTime.class),
+                any(Pageable.class)
+        )).thenReturn(List.of(event));
+        doThrow(new RuntimeException("AI server unavailable"))
+                .when(aiCleanupClient).deleteProjectResources(1L);
+
+        outboxWorker.processPendingEvents();
+
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+        assertThat(event.getRetryCount()).isEqualTo(1);
+        assertThat(event.getErrorMessage()).contains("AI server unavailable");
+        assertThat(event.getNextRetryAt()).isAfter(LocalDateTime.now());
+    }
+}

--- a/src/test/java/markoala/fithub/demo/domain/project/ProjectServiceTest.java
+++ b/src/test/java/markoala/fithub/demo/domain/project/ProjectServiceTest.java
@@ -1,5 +1,7 @@
 package markoala.fithub.demo.domain.project;
 
+import markoala.fithub.demo.domain.outbox.OutboxEventRepository;
+import markoala.fithub.demo.domain.outbox.OutboxEventType;
 import markoala.fithub.demo.domain.project.dto.ProjectCreateRequest;
 import markoala.fithub.demo.domain.project.dto.ProjectUpdateRequest;
 import markoala.fithub.demo.domain.project.dto.ProjectCreateResponse;
@@ -35,6 +37,9 @@ class ProjectServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
 
     @InjectMocks
     private ProjectService projectService;
@@ -195,6 +200,10 @@ class ProjectServiceTest {
 
         verify(projectMemberRepository).deleteAll(List.of(member));
         verify(projectRepository).delete(project);
+        verify(outboxEventRepository).save(argThat(event ->
+                event.getEventType() == OutboxEventType.PROJECT_DELETED
+                        && event.getAggregateId().equals(1L)
+        ));
     }
 
     @Test


### PR DESCRIPTION
### 작업 내용
- [x] 프로젝트 삭제 시 `PROJECT_DELETED` outbox 이벤트를 저장하도록 구현
- [x] `outbox_events` 엔티티, 이벤트 타입/상태 enum, 리포지토리 추가
- [x] `OutboxWorker`를 추가해 `PENDING` 이벤트를 AI 서버 cleanup API로 전달
- [x] AI 서버 프로젝트 cleanup 호출용 `AiCleanupClient` 추가
- [x] 프로젝트 삭제 이벤트 저장 및 worker 성공/실패 처리 테스트 추가